### PR TITLE
Release 0.7.3-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/common/ped/IPedsManager.ts
+++ b/src/server/entities/common/ped/IPedsManager.ts
@@ -1,7 +1,9 @@
 import { IEntitiesManager, IEntityCreateOptions } from "../entity";
 import { IPed } from "./IPed";
 
-export interface IPedCreateOptions extends IEntityCreateOptions {}
+export interface IPedCreateOptions extends IEntityCreateOptions {
+  frozen: boolean;
+}
 
 export interface IPedsManager extends IEntitiesManager<IPed> {
   create(options: IPedCreateOptions): IPed;

--- a/src/server/entities/ragemp/ped/RagePedsManager.ts
+++ b/src/server/entities/ragemp/ped/RagePedsManager.ts
@@ -12,11 +12,12 @@ export class RagePedsManager extends RageEntitiesManager<RagePed> implements IPe
   }
 
   public create(options: IRagePedCreateOptions): RagePed {
-    const { model, position, dimension, rotation } = options;
+    const { model, frozen, position, dimension, rotation } = options;
 
     const mpEntity = mp.peds.new(mp.joaat(model), new mp.Vector3(position), {
       dimension,
       heading: rotation.z,
+      frozen,
     });
     mpEntity.isExists = (): boolean => mp.peds.exists(mpEntity);
 


### PR DESCRIPTION
### v0.7.3 Release Notes  

- **Added**: Support for the `frozen` option for pedestrians (peds) in RageMP.  
  This allows controlling whether a ped is frozen in place.  

This update improves the flexibility of ped management in RageMP environments.