### PR TITLE
Release 0.8.3-alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/ragemp/baseObject/RageBaseObject.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObject.ts
@@ -1,7 +1,7 @@
 import { BaseObjectType, IBaseObject, IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
 
 // RAGEMP BUG: event 'entityDestroyed' is not callable
-const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object"]);
+const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object", "vehicle"]);
 
 export interface IRageBaseObjectOptions<T extends EntityMp> extends IBaseObjectOptions {
   mpEntity: T;


### PR DESCRIPTION
# Release Notes

## 🐛 Bug Fixes
- Added vehicle entities to the list of unsupported RAGEMP entity types due to `entityDestroyed` event bug
- This fix prevents potential issues when handling vehicle destruction events in RAGEMP environment

## 🔍 Technical Details
- Updated `unsupportedRageEntityTypes` set in `RageBaseObject.ts`
- Affected entity types now include: "blip", "colshape", "object", and "vehicle"

## 💡 Developer Notes
- If you're working with vehicle entities in RAGEMP, be aware that the `entityDestroyed` event won't be triggered
- Consider implementing alternative destruction tracking mechanisms for vehicles in your application