### PR TITLE
Release 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/.eslintrc.json
+++ b/src/client/.eslintrc.json
@@ -46,7 +46,14 @@
       }
     ],
     "@typescript-eslint/explicit-function-return-type": ["error"],
-    "@typescript-eslint/explicit-member-accessibility": ["error"]
+    "@typescript-eslint/explicit-member-accessibility": ["error"],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "inline-type-imports"
+      }
+    ]
   },
   "settings": {
     "import/resolver": {

--- a/src/client/RockMod.ts
+++ b/src/client/RockMod.ts
@@ -1,15 +1,15 @@
-import { INetManager } from "./net/common/INetManager";
+import { type INetManager } from "./net/common/INetManager";
 import {
-  IBlipsManager,
-  IColshapesManager,
-  IMarkersManager,
-  IObjectsManager,
-  IPedsManager,
-  IPlayersManager,
-  IVehiclesManager,
+  type IBlipsManager,
+  type IColshapesManager,
+  type IMarkersManager,
+  type IObjectsManager,
+  type IPedsManager,
+  type IPlayersManager,
+  type IVehiclesManager,
 } from "./entities";
-import { IUtilsManager } from "./utils";
-import { IManagersFactory } from "./factories/common/IManagersFactory";
+import { type IUtilsManager } from "./utils";
+import { type IManagersFactory } from "./factories/common/IManagersFactory";
 
 type MultiplayerType = "RageMP" | "AltV" | "Mock";
 

--- a/src/client/entities/common/baseObject/IBaseObject.ts
+++ b/src/client/entities/common/baseObject/IBaseObject.ts
@@ -1,5 +1,5 @@
 import BaseObject = AltVClient.BaseObject;
-import { BaseObjectType } from "@shared/entities";
+import { type BaseObjectType } from "@shared/entities";
 
 export interface IBaseObjectOptions {
   mpEntity: EntityMp | BaseObject;

--- a/src/client/entities/common/baseObject/IBaseObjectsIterator.ts
+++ b/src/client/entities/common/baseObject/IBaseObjectsIterator.ts
@@ -1,4 +1,4 @@
-import { IBaseObject } from "./IBaseObject";
+import { type IBaseObject } from "./IBaseObject";
 
 export interface IBaseObjectsIterator<T extends IBaseObject> {
   all(): IterableIterator<T>;

--- a/src/client/entities/common/baseObject/IBaseObjectsManager.ts
+++ b/src/client/entities/common/baseObject/IBaseObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IBaseObject } from "./IBaseObject";
-import { IBaseObjectsIterator } from "./IBaseObjectsIterator";
-import { BaseObjectType } from "@shared/entities";
+import { type IBaseObject } from "./IBaseObject";
+import { type IBaseObjectsIterator } from "./IBaseObjectsIterator";
+import { type BaseObjectType } from "@shared/entities";
 
 export interface IBaseObjectsManagerOptions {
   baseObjectsType: `${BaseObjectType}`;

--- a/src/client/entities/common/blip/IBlip.ts
+++ b/src/client/entities/common/blip/IBlip.ts
@@ -1,5 +1,5 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
-import { IBlipColor, IBlipSprite } from "@shared/entities";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
+import { type IBlipColor, type IBlipSprite } from "@shared/entities";
 
 export interface IBlipOptions extends IWorldObjectOptions {}
 

--- a/src/client/entities/common/blip/IBlipsManager.ts
+++ b/src/client/entities/common/blip/IBlipsManager.ts
@@ -1,5 +1,5 @@
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IBlip } from "./IBlip";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IBlip } from "./IBlip";
 
 export interface IBlipCreateOptions extends IWorldObjectCreateOptions {
   alpha?: number;

--- a/src/client/entities/common/colshape/ICircleColshape.ts
+++ b/src/client/entities/common/colshape/ICircleColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICircleColshapeOptions extends IColshapeOptions {}
 

--- a/src/client/entities/common/colshape/IColshape.ts
+++ b/src/client/entities/common/colshape/IColshape.ts
@@ -1,4 +1,4 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
 
 export interface IColshapeOptions extends IWorldObjectOptions {}
 

--- a/src/client/entities/common/colshape/IColshapesManager.ts
+++ b/src/client/entities/common/colshape/IColshapesManager.ts
@@ -1,11 +1,11 @@
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IColshape } from "./IColshape";
-import { ICircleColshape } from "./ICircleColshape";
-import { ICuboidColshape } from "./ICuboidColshape";
-import { ICylinderColshape } from "./ICylinderColshape";
-import { IRectangleColshape } from "./IRectangleColshape";
-import { ISphereColshape } from "./ISphereColshape";
-import { IVector2D } from "@shared/common/utils";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IColshape } from "./IColshape";
+import { type ICircleColshape } from "./ICircleColshape";
+import { type ICuboidColshape } from "./ICuboidColshape";
+import { type ICylinderColshape } from "./ICylinderColshape";
+import { type IRectangleColshape } from "./IRectangleColshape";
+import { type ISphereColshape } from "./ISphereColshape";
+import { type IVector2D } from "@shared/common/utils";
 
 export interface ICircleColshapeCreateOptions extends Omit<IWorldObjectCreateOptions, "position"> {
   position: IVector2D;

--- a/src/client/entities/common/colshape/ICuboidColshape.ts
+++ b/src/client/entities/common/colshape/ICuboidColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICuboidColshapeOptions extends IColshapeOptions {}
 

--- a/src/client/entities/common/colshape/ICylinderColshape.ts
+++ b/src/client/entities/common/colshape/ICylinderColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICylinderColshapeOptions extends IColshapeOptions {}
 

--- a/src/client/entities/common/colshape/IRectangleColshape.ts
+++ b/src/client/entities/common/colshape/IRectangleColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface IRectangleColshapeOptions extends IColshapeOptions {}
 

--- a/src/client/entities/common/colshape/ISphereColshape.ts
+++ b/src/client/entities/common/colshape/ISphereColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ISphereColshapeOptions extends IColshapeOptions {}
 

--- a/src/client/entities/common/entity/IEntitiesManager.ts
+++ b/src/client/entities/common/entity/IEntitiesManager.ts
@@ -1,10 +1,10 @@
 import {
-  IWorldObjectCreateOptions,
-  IWorldObjectsManager,
-  IWorldObjectsManagerOptions,
+  type IWorldObjectCreateOptions,
+  type IWorldObjectsManager,
+  type IWorldObjectsManagerOptions,
 } from "../worldObject/IWorldObjectsManager";
-import { IEntity } from "./IEntity";
-import { IVector3D } from "@shared/common/utils";
+import { type IEntity } from "./IEntity";
+import { type IVector3D } from "@shared/common/utils";
 
 export interface IEntitiesManagerOptions extends IWorldObjectsManagerOptions {}
 

--- a/src/client/entities/common/entity/IEntity.ts
+++ b/src/client/entities/common/entity/IEntity.ts
@@ -1,5 +1,5 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject/IWorldObject";
-import { IVector3D } from "@shared/common/utils";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject/IWorldObject";
+import { type IVector3D } from "@shared/common/utils";
 
 export interface IEntityOptions extends IWorldObjectOptions {}
 

--- a/src/client/entities/common/marker/IMarker.ts
+++ b/src/client/entities/common/marker/IMarker.ts
@@ -1,6 +1,6 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
-import { IRGBA, IVector3D } from "@shared/common/utils";
-import { IMarkerType } from "@shared/entities";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
+import { type IRGBA, type IVector3D } from "@shared/common/utils";
+import { type IMarkerType } from "@shared/entities";
 
 export interface IMarkerOptions extends IWorldObjectOptions {
   type: IMarkerType;

--- a/src/client/entities/common/marker/IMarkersManager.ts
+++ b/src/client/entities/common/marker/IMarkersManager.ts
@@ -1,7 +1,7 @@
-import { IMarker } from "./IMarker";
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IRGBA, IVector3D } from "@shared/common/utils";
-import { IMarkerType } from "@shared/entities";
+import { type IMarker } from "./IMarker";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IRGBA, type IVector3D } from "@shared/common/utils";
+import { type IMarkerType } from "@shared/entities";
 
 export interface IMarkerCreateOptions extends IWorldObjectCreateOptions {
   type: IMarkerType;

--- a/src/client/entities/common/object/IObject.ts
+++ b/src/client/entities/common/object/IObject.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity";
+import { type IEntity, type IEntityOptions } from "../entity";
 
 export interface IObjectOptions extends IEntityOptions {}
 

--- a/src/client/entities/common/object/IObjectsManager.ts
+++ b/src/client/entities/common/object/IObjectsManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity";
-import { IObject } from "./IObject";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity";
+import { type IObject } from "./IObject";
 
 export interface IObjectCreateOptions extends IEntityCreateOptions {
   alpha: number;

--- a/src/client/entities/common/ped/IPed.ts
+++ b/src/client/entities/common/ped/IPed.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity";
+import { type IEntity, type IEntityOptions } from "../entity";
 
 export interface IPedOptions extends IEntityOptions {}
 

--- a/src/client/entities/common/ped/IPedsManager.ts
+++ b/src/client/entities/common/ped/IPedsManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity";
-import { IPed } from "./IPed";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity";
+import { type IPed } from "./IPed";
 
 export interface IPedCreateOptions extends IEntityCreateOptions {}
 

--- a/src/client/entities/common/player/IPlayer.ts
+++ b/src/client/entities/common/player/IPlayer.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity/IEntity";
+import { type IEntity, type IEntityOptions } from "../entity/IEntity";
 
 export interface IPlayerOptions extends IEntityOptions {}
 

--- a/src/client/entities/common/player/IPlayersManager.ts
+++ b/src/client/entities/common/player/IPlayersManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager } from "../entity/IEntitiesManager";
-import { IPlayer } from "./IPlayer";
+import { type IEntitiesManager } from "../entity/IEntitiesManager";
+import { type IPlayer } from "./IPlayer";
 
 export interface IPlayersManager extends IEntitiesManager<IPlayer> {
   getByName(name: string): IPlayer;

--- a/src/client/entities/common/vehicle/IVehicle.ts
+++ b/src/client/entities/common/vehicle/IVehicle.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity/IEntity";
+import { type IEntity, type IEntityOptions } from "../entity/IEntity";
 
 export interface IVehicleOptions extends IEntityOptions {}
 

--- a/src/client/entities/common/vehicle/IVehiclesManager.ts
+++ b/src/client/entities/common/vehicle/IVehiclesManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity/IEntitiesManager";
-import { IVehicle } from "./IVehicle";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity/IEntitiesManager";
+import { type IVehicle } from "./IVehicle";
 
 export interface IVehicleCreateOptions extends IEntityCreateOptions {
   engine: boolean;

--- a/src/client/entities/common/worldObject/IWorldObject.ts
+++ b/src/client/entities/common/worldObject/IWorldObject.ts
@@ -1,5 +1,5 @@
-import { IBaseObject, IBaseObjectOptions } from "../baseObject";
-import { IVector3D } from "@shared/common/utils";
+import { type IBaseObject, type IBaseObjectOptions } from "../baseObject";
+import { type IVector3D } from "@shared/common/utils";
 
 export interface IWorldObjectOptions extends IBaseObjectOptions {}
 

--- a/src/client/entities/common/worldObject/IWorldObjectsIterator.ts
+++ b/src/client/entities/common/worldObject/IWorldObjectsIterator.ts
@@ -1,6 +1,6 @@
-import { IBaseObjectsIterator } from "../baseObject/IBaseObjectsIterator";
-import { IWorldObject } from "./IWorldObject";
-import { Vector2D, Vector3D } from "@shared/common/utils";
+import { type IBaseObjectsIterator } from "../baseObject/IBaseObjectsIterator";
+import { type IWorldObject } from "./IWorldObject";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
 
 export interface IWorldObjectsIterator<T extends IWorldObject> extends IBaseObjectsIterator<T> {
   dimension(value: number): IterableIterator<T>;

--- a/src/client/entities/common/worldObject/IWorldObjectsManager.ts
+++ b/src/client/entities/common/worldObject/IWorldObjectsManager.ts
@@ -1,7 +1,11 @@
-import { IBaseObjectCreateOptions, IBaseObjectsManager, IBaseObjectsManagerOptions } from "../baseObject";
-import { IWorldObject } from "./IWorldObject";
-import { IWorldObjectsIterator } from "./IWorldObjectsIterator";
-import { IVector3D } from "@shared/common/utils";
+import {
+  type IBaseObjectCreateOptions,
+  type IBaseObjectsManager,
+  type IBaseObjectsManagerOptions,
+} from "../baseObject";
+import { type IWorldObject } from "./IWorldObject";
+import { type IWorldObjectsIterator } from "./IWorldObjectsIterator";
+import { type IVector3D } from "@shared/common/utils";
 
 export interface IWorldObjectsManagerOptions extends IBaseObjectsManagerOptions {}
 

--- a/src/client/entities/ragemp/baseObject/RageBaseObject.ts
+++ b/src/client/entities/ragemp/baseObject/RageBaseObject.ts
@@ -1,5 +1,5 @@
-import { BaseObjectType } from "@shared/entities";
-import { IBaseObject, IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
+import { type BaseObjectType } from "@shared/entities";
+import { type IBaseObject, type IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
 
 export interface IRageBaseObjectOptions<T extends EntityMp> extends IBaseObjectOptions {
   mpEntity: T;

--- a/src/client/entities/ragemp/baseObject/RageBaseObjectsIterator.ts
+++ b/src/client/entities/ragemp/baseObject/RageBaseObjectsIterator.ts
@@ -1,5 +1,5 @@
-import { IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
-import { RageBaseObject } from "./RageBaseObject";
+import { type IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
+import { type RageBaseObject } from "./RageBaseObject";
 
 export class RageBaseObjectsIterator<T extends RageBaseObject> implements IBaseObjectsIterator<T> {
   private readonly _baseObjects: ReadonlyMap<number, T>;

--- a/src/client/entities/ragemp/baseObject/RageBaseObjectsManager.ts
+++ b/src/client/entities/ragemp/baseObject/RageBaseObjectsManager.ts
@@ -1,8 +1,8 @@
-import { IBaseObjectsManager, IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
-import { RageBaseObject } from "./RageBaseObject";
+import { type IBaseObjectsManager, type IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
+import { type RageBaseObject } from "./RageBaseObject";
 import { RageBaseObjectsIterator } from "./RageBaseObjectsIterator";
 import { RockMod } from "../../../RockMod";
-import { BaseObjectType } from "@shared/entities";
+import { type BaseObjectType } from "@shared/entities";
 import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
 
 export interface IRageBaseObjectsManagerOptions extends IBaseObjectsManagerOptions {}

--- a/src/client/entities/ragemp/blip/RageBlip.ts
+++ b/src/client/entities/ragemp/blip/RageBlip.ts
@@ -1,6 +1,6 @@
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
-import { IBlip } from "../../common/blip/IBlip";
-import { IBlipColor, IBlipSprite } from "@shared/entities";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IBlip } from "../../common/blip/IBlip";
+import { type IBlipColor, type IBlipSprite } from "@shared/entities";
 
 export interface IRageBlipOptions extends IRageWorldObjectOptions<EntityMp> {}
 

--- a/src/client/entities/ragemp/blip/RageBlipsManager.ts
+++ b/src/client/entities/ragemp/blip/RageBlipsManager.ts
@@ -1,4 +1,4 @@
-import { IBlipCreateOptions, IBlipsManager } from "../../common";
+import { type IBlipCreateOptions, type IBlipsManager } from "../../common";
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 import { RageBlip } from "./RageBlip";
 

--- a/src/client/entities/ragemp/colshape/RageCircleColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageCircleColshape.ts
@@ -1,5 +1,5 @@
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
-import { ICircleColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICircleColshape } from "../../common";
 
 export interface IRageCircleColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/client/entities/ragemp/colshape/RageColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageColshape.ts
@@ -1,4 +1,4 @@
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
 
 export interface IRageColshapeOptions extends IRageWorldObjectOptions<ColshapeMp> {}
 

--- a/src/client/entities/ragemp/colshape/RageColshapesManager.ts
+++ b/src/client/entities/ragemp/colshape/RageColshapesManager.ts
@@ -1,12 +1,12 @@
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
-import { RageColshape } from "./RageColshape";
+import { type RageColshape } from "./RageColshape";
 import {
-  ICircleColshapeCreateOptions,
-  IColshapesManager,
-  ICuboidColshapeCreateOptions,
-  ICylinderColshapeCreateOptions,
-  IRectangleColshapeCreateOptions,
-  ISphereColshapeCreateOptions,
+  type ICircleColshapeCreateOptions,
+  type IColshapesManager,
+  type ICuboidColshapeCreateOptions,
+  type ICylinderColshapeCreateOptions,
+  type IRectangleColshapeCreateOptions,
+  type ISphereColshapeCreateOptions,
 } from "../../common";
 import { RageCircleColshape } from "./RageCircleColshape";
 import { RageCuboidColshape } from "./RageCuboidColshape";

--- a/src/client/entities/ragemp/colshape/RageCuboidColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageCuboidColshape.ts
@@ -1,5 +1,5 @@
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
-import { ICuboidColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICuboidColshape } from "../../common";
 
 export interface IRageCuboidColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/client/entities/ragemp/colshape/RageCylinderColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageCylinderColshape.ts
@@ -1,5 +1,5 @@
-import { ICylinderColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICylinderColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageCylinderColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/client/entities/ragemp/colshape/RageRectangleColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageRectangleColshape.ts
@@ -1,5 +1,5 @@
-import { IRectangleColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type IRectangleColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageRectangleColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/client/entities/ragemp/colshape/RageSphereColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageSphereColshape.ts
@@ -1,5 +1,5 @@
-import { ISphereColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ISphereColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageSphereColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/client/entities/ragemp/entity/RageEntitiesManager.ts
+++ b/src/client/entities/ragemp/entity/RageEntitiesManager.ts
@@ -1,6 +1,6 @@
-import { IEntitiesManager } from "../../common/entity/IEntitiesManager";
-import { RageEntity } from "./RageEntity";
-import { IRageWorldObjectsManagerOptions, RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
+import { type IEntitiesManager } from "../../common/entity/IEntitiesManager";
+import { type RageEntity } from "./RageEntity";
+import { type IRageWorldObjectsManagerOptions, RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 
 export interface IRageEntitiesManagerOptions extends IRageWorldObjectsManagerOptions {}
 

--- a/src/client/entities/ragemp/entity/RageEntity.ts
+++ b/src/client/entities/ragemp/entity/RageEntity.ts
@@ -1,5 +1,5 @@
-import { IEntity } from "../../common/entity/IEntity";
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IEntity } from "../../common/entity/IEntity";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
 import { Vector3D } from "../../../../shared/common/utils";
 
 export interface IRageEntityOptions<T extends EntityMp> extends IRageWorldObjectOptions<T> {}

--- a/src/client/entities/ragemp/marker/RageMarker.ts
+++ b/src/client/entities/ragemp/marker/RageMarker.ts
@@ -1,7 +1,7 @@
-import { IMarker } from "../../common";
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
-import { IVector3D, Vector3D } from "../../../../shared/common/utils";
-import { IMarkerType } from "@shared/entities";
+import { type IMarker } from "../../common";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IVector3D, Vector3D } from "../../../../shared/common/utils";
+import { type IMarkerType } from "@shared/entities";
 
 export interface IRageMarkerOptions extends IRageWorldObjectOptions<MarkerMp> {}
 

--- a/src/client/entities/ragemp/marker/RageMarkersManager.ts
+++ b/src/client/entities/ragemp/marker/RageMarkersManager.ts
@@ -1,4 +1,4 @@
-import { IMarkerCreateOptions, IMarkersManager } from "../../common";
+import { type IMarkerCreateOptions, type IMarkersManager } from "../../common";
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 import { RageMarker } from "./RageMarker";
 

--- a/src/client/entities/ragemp/object/RageObject.ts
+++ b/src/client/entities/ragemp/object/RageObject.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IObject } from "../../common/object/IObject";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IObject } from "../../common/object/IObject";
 
 export interface IRageObjectOptions extends IRageEntityOptions<ObjectMp> {}
 

--- a/src/client/entities/ragemp/object/RageObjectsManager.ts
+++ b/src/client/entities/ragemp/object/RageObjectsManager.ts
@@ -1,4 +1,4 @@
-import { IObjectCreateOptions, IObjectsManager } from "../../common/object/IObjectsManager";
+import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RageObject } from "./RageObject";
 

--- a/src/client/entities/ragemp/ped/RagePed.ts
+++ b/src/client/entities/ragemp/ped/RagePed.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IPed } from "../../common";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IPed } from "../../common";
 
 export interface IRagePedOptions extends IRageEntityOptions<PedMp> {}
 

--- a/src/client/entities/ragemp/ped/RagePedsManager.ts
+++ b/src/client/entities/ragemp/ped/RagePedsManager.ts
@@ -1,4 +1,4 @@
-import { IPedCreateOptions, IPedsManager } from "../../common";
+import { type IPedCreateOptions, type IPedsManager } from "../../common";
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RagePed } from "./RagePed";
 

--- a/src/client/entities/ragemp/player/RagePlayer.ts
+++ b/src/client/entities/ragemp/player/RagePlayer.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IPlayer } from "../../common/player/IPlayer";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IPlayer } from "../../common/player/IPlayer";
 
 interface IRagePlayerOptions extends IRageEntityOptions<PlayerMp> {}
 

--- a/src/client/entities/ragemp/player/RagePlayersManager.ts
+++ b/src/client/entities/ragemp/player/RagePlayersManager.ts
@@ -1,7 +1,7 @@
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RagePlayer } from "./RagePlayer";
-import { IPlayersManager } from "../../common/player/IPlayersManager";
-import { RageNetManager } from "../../../net/ragemp/RageNetManager";
+import { type IPlayersManager } from "../../common/player/IPlayersManager";
+import { type RageNetManager } from "../../../net/ragemp/RageNetManager";
 import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
 
 export class RagePlayersManager extends RageEntitiesManager<RagePlayer> implements IPlayersManager {

--- a/src/client/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehicle.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IVehicle } from "../../common/vehicle/IVehicle";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IVehicle } from "../../common/vehicle/IVehicle";
 
 export interface IRageVehicleOptions extends IRageEntityOptions<VehicleMp> {}
 

--- a/src/client/entities/ragemp/vehicle/RageVehiclesManager.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehiclesManager.ts
@@ -1,6 +1,6 @@
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RageVehicle } from "./RageVehicle";
-import { IVehicleCreateOptions, IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
+import { type IVehicleCreateOptions, type IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
 
 export interface IRageVehicleCreateOptions extends IVehicleCreateOptions {}
 

--- a/src/client/entities/ragemp/worldObject/RageWorldObject.ts
+++ b/src/client/entities/ragemp/worldObject/RageWorldObject.ts
@@ -1,5 +1,5 @@
-import { IWorldObject } from "../../common/worldObject/IWorldObject";
-import { IRageBaseObjectOptions, RageBaseObject } from "../baseObject/RageBaseObject";
+import { type IWorldObject } from "../../common/worldObject/IWorldObject";
+import { type IRageBaseObjectOptions, RageBaseObject } from "../baseObject/RageBaseObject";
 import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export interface IRageWorldObjectOptions<T extends EntityMp> extends IRageBaseObjectOptions<T> {}

--- a/src/client/entities/ragemp/worldObject/RageWorldObjectsIterator.ts
+++ b/src/client/entities/ragemp/worldObject/RageWorldObjectsIterator.ts
@@ -1,7 +1,7 @@
-import { RageWorldObject } from "./RageWorldObject";
+import { type RageWorldObject } from "./RageWorldObject";
 import { RageBaseObjectsIterator } from "../baseObject/RageBaseObjectsIterator";
-import { IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
-import { Vector2D, Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { type Vector2D, type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export class RageWorldObjectsIterator<T extends RageWorldObject<EntityMp>>
   extends RageBaseObjectsIterator<T>

--- a/src/client/entities/ragemp/worldObject/RageWorldObjectsManager.ts
+++ b/src/client/entities/ragemp/worldObject/RageWorldObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IWorldObjectsManager } from "../../common";
-import { IRageBaseObjectsManagerOptions, RageBaseObjectsManager } from "../baseObject/RageBaseObjectsManager";
-import { RageWorldObject } from "./RageWorldObject";
+import { type IWorldObjectsManager } from "../../common";
+import { type IRageBaseObjectsManagerOptions, RageBaseObjectsManager } from "../baseObject/RageBaseObjectsManager";
+import { type RageWorldObject } from "./RageWorldObject";
 import { RageWorldObjectsIterator } from "./RageWorldObjectsIterator";
 
 export interface IRageWorldObjectsManagerOptions extends IRageBaseObjectsManagerOptions {}

--- a/src/client/factories/common/IManagersFactory.ts
+++ b/src/client/factories/common/IManagersFactory.ts
@@ -1,14 +1,14 @@
-import { INetManager } from "../../net/common/INetManager";
+import { type INetManager } from "../../net/common/INetManager";
 import {
-  IBlipsManager,
-  IColshapesManager,
-  IMarkersManager,
-  IObjectsManager,
-  IPedsManager,
-  IPlayersManager,
-  IVehiclesManager,
+  type IBlipsManager,
+  type IColshapesManager,
+  type IMarkersManager,
+  type IObjectsManager,
+  type IPedsManager,
+  type IPlayersManager,
+  type IVehiclesManager,
 } from "../../entities";
-import { IUtilsManager } from "../../utils";
+import { type IUtilsManager } from "../../utils";
 
 export interface IManagersFactory {
   createNetManager(): INetManager;

--- a/src/client/factories/ragemp/RageManagersFactory.ts
+++ b/src/client/factories/ragemp/RageManagersFactory.ts
@@ -1,4 +1,4 @@
-import { IManagersFactory } from "../common/IManagersFactory";
+import { type IManagersFactory } from "../common/IManagersFactory";
 import { RageBlipsManager } from "@RockMod/client/entities/ragemp/blip/RageBlipsManager";
 import { RageColshapesManager } from "@RockMod/client/entities/ragemp/colshape/RageColshapesManager";
 import { RageMarkersManager } from "@RockMod/client/entities/ragemp/marker/RageMarkersManager";

--- a/src/client/net/common/INetManager.ts
+++ b/src/client/net/common/INetManager.ts
@@ -1,5 +1,5 @@
-import { IEventsManager } from "./events/IEventsManager";
-import { IRPCManager } from "./rpc/IRPCManager";
+import { type IEventsManager } from "./events/IEventsManager";
+import { type IRPCManager } from "./rpc/IRPCManager";
 
 export interface INetManager {
   get events(): IEventsManager;

--- a/src/client/net/common/events/IEventsManager.ts
+++ b/src/client/net/common/events/IEventsManager.ts
@@ -1,5 +1,5 @@
-import { IServerToClientEvents, IClientToServerEvents } from "@shared/net/common/events/types";
-import { IClientInternalEvents } from "./types";
+import { type IServerToClientEvents, type IClientToServerEvents } from "@shared/net/common/events/types";
+import { type IClientInternalEvents } from "./types";
 
 export interface IEventsManager {
   onInternal(events: Partial<IClientInternalEvents>): void;

--- a/src/client/net/common/events/types.ts
+++ b/src/client/net/common/events/types.ts
@@ -1,4 +1,4 @@
-import { IBaseObject, IPlayer } from "@RockMod/client/entities";
+import { type IBaseObject, type IPlayer } from "@RockMod/client/entities";
 
 export enum ClientInternalEventName {
   PlayerConnected = "rm::playerConnected",

--- a/src/client/net/common/rpc/IRPCManager.ts
+++ b/src/client/net/common/rpc/IRPCManager.ts
@@ -1,4 +1,4 @@
-import { IClientRPCList, IServerRPCList } from "@shared/net/common/rpc/types";
+import { type IClientRPCList, type IServerRPCList } from "@shared/net/common/rpc/types";
 
 export interface IRPCManager {
   register<K extends keyof IClientRPCList>(

--- a/src/client/net/ragemp/RageNetManager.ts
+++ b/src/client/net/ragemp/RageNetManager.ts
@@ -1,4 +1,4 @@
-import { INetManager } from "../common/INetManager";
+import { type INetManager } from "../common/INetManager";
 import { RageEventsManager } from "./events/RageEventsManager";
 import { RageRPCManager } from "./rpc/RageRPCManager";
 

--- a/src/client/net/ragemp/events/RageEventsManager.ts
+++ b/src/client/net/ragemp/events/RageEventsManager.ts
@@ -1,6 +1,6 @@
-import { IEventsManager } from "../../common/events/IEventsManager";
-import { IClientInternalEvents } from "@RockMod/client/net/common/events/types";
-import { IClientToServerEvents, IServerToClientEvents } from "@shared/net/common/events/types";
+import { type IEventsManager } from "../../common/events/IEventsManager";
+import { type IClientInternalEvents } from "@RockMod/client/net/common/events/types";
+import { type IClientToServerEvents, type IServerToClientEvents } from "@shared/net/common/events/types";
 
 interface IRageClientInternalEvents extends IClientInternalEvents, IClientEvents {}
 

--- a/src/client/net/ragemp/rpc/RageRPCManager.ts
+++ b/src/client/net/ragemp/rpc/RageRPCManager.ts
@@ -1,5 +1,5 @@
-import { IRPCManager } from "../../common/rpc/IRPCManager";
-import { IClientRPCList, IServerRPCList } from "@shared/net/common/rpc/types";
+import { type IRPCManager } from "../../common/rpc/IRPCManager";
+import { type IClientRPCList, type IServerRPCList } from "@shared/net/common/rpc/types";
 
 export class RageRPCManager implements IRPCManager {
   public register<K extends keyof IClientRPCList>(

--- a/src/client/utils/ragemp/RageUtilsManager.ts
+++ b/src/client/utils/ragemp/RageUtilsManager.ts
@@ -1,4 +1,4 @@
-import { IUtilsManager } from "../common";
+import { type IUtilsManager } from "../common";
 
 export class RageUtilsManager implements IUtilsManager {
   public hash(value: string): number {

--- a/src/server/.eslintrc.json
+++ b/src/server/.eslintrc.json
@@ -46,7 +46,14 @@
       }
     ],
     "@typescript-eslint/explicit-function-return-type": ["error"],
-    "@typescript-eslint/explicit-member-accessibility": ["error"]
+    "@typescript-eslint/explicit-member-accessibility": ["error"],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "inline-type-imports"
+      }
+    ]
   },
   "settings": {
     "import/resolver": {

--- a/src/server/RockMod.ts
+++ b/src/server/RockMod.ts
@@ -1,15 +1,15 @@
-import { INetManager } from "./net/common/INetManager";
+import { type INetManager } from "./net/common/INetManager";
 import {
-  IBlipsManager,
-  IColshapesManager,
-  IMarkersManager,
-  IObjectsManager,
-  IPedsManager,
-  IPlayersManager,
-  IVehiclesManager,
+  type IBlipsManager,
+  type IColshapesManager,
+  type IMarkersManager,
+  type IObjectsManager,
+  type IPedsManager,
+  type IPlayersManager,
+  type IVehiclesManager,
 } from "./entities";
-import { IUtilsManager } from "./utils";
-import { IManagersFactory } from "./factories/common/IManagersFactory";
+import { type IUtilsManager } from "./utils";
+import { type IManagersFactory } from "./factories/common/IManagersFactory";
 
 type MultiplayerType = "RageMP" | "AltV" | "Mock";
 

--- a/src/server/entities/altv/baseObject/AltVBaseObject.ts
+++ b/src/server/entities/altv/baseObject/AltVBaseObject.ts
@@ -1,4 +1,4 @@
-import { IBaseObject, IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
+import { type IBaseObject, type IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
 import BaseObject = AltVServer.BaseObject;
 import BaseObjectTypeMP = AltVShared.BaseObjectType;
 import { BaseObjectType } from "../../../../shared";

--- a/src/server/entities/altv/baseObject/AltVBaseObjectsIterator.ts
+++ b/src/server/entities/altv/baseObject/AltVBaseObjectsIterator.ts
@@ -1,5 +1,5 @@
-import { AltVBaseObject } from "./AltVBaseObject";
-import { IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
+import { type AltVBaseObject } from "./AltVBaseObject";
+import { type IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
 import BaseObject = AltVServer.BaseObject;
 
 export class AltVBaseObjectsIterator<T extends AltVBaseObject<BaseObject>> implements IBaseObjectsIterator<T> {

--- a/src/server/entities/altv/baseObject/AltVBaseObjectsManager.ts
+++ b/src/server/entities/altv/baseObject/AltVBaseObjectsManager.ts
@@ -1,8 +1,8 @@
-import { IBaseObjectsManager, IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
-import { AltVBaseObject } from "./AltVBaseObject";
+import { type IBaseObjectsManager, type IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
+import { type AltVBaseObject } from "./AltVBaseObject";
 import { AltVBaseObjectsIterator } from "./AltVBaseObjectsIterator";
 import { RockMod } from "../../../RockMod";
-import { BaseObjectType } from "../../../../shared";
+import { type BaseObjectType } from "../../../../shared";
 import BaseObject = AltVServer.BaseObject;
 import { ServerInternalEventName } from "../../../net/common/events/types";
 

--- a/src/server/entities/altv/blip/AltVBlip.ts
+++ b/src/server/entities/altv/blip/AltVBlip.ts
@@ -1,7 +1,7 @@
-import { AltVWorldObject, IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
-import { IBlip } from "../../common";
+import { AltVWorldObject, type IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
+import { type IBlip } from "../../common";
 import BlipSprite = AltVShared.BlipSprite;
-import { IBlipColor, IBlipSprite } from "../../../../shared";
+import { type IBlipColor, type IBlipSprite } from "../../../../shared";
 
 export interface IAltVBlipOptions extends IAltVWorldObjectOptions<AltVServer.Blip> {}
 

--- a/src/server/entities/altv/blip/AltVBlipsManager.ts
+++ b/src/server/entities/altv/blip/AltVBlipsManager.ts
@@ -1,4 +1,4 @@
-import { IBlipCreateOptions, IBlipsManager } from "../../common";
+import { type IBlipCreateOptions, type IBlipsManager } from "../../common";
 import { AltVWorldObjectsManager } from "../worldObject/AltVWorldObjectsManager";
 import { AltVBlip } from "./AltVBlip";
 import PointBlip = AltVServer.PointBlip;

--- a/src/server/entities/altv/colshape/AltVCircleColshape.ts
+++ b/src/server/entities/altv/colshape/AltVCircleColshape.ts
@@ -1,5 +1,5 @@
-import { ICircleColshape } from "../../common";
-import { AltVColshape, IAltVColshapeOptions } from "./AltVColshape";
+import { type ICircleColshape } from "../../common";
+import { AltVColshape, type IAltVColshapeOptions } from "./AltVColshape";
 
 export interface IAltVCircleColshapeOptions extends IAltVColshapeOptions {}
 

--- a/src/server/entities/altv/colshape/AltVColshape.ts
+++ b/src/server/entities/altv/colshape/AltVColshape.ts
@@ -1,4 +1,4 @@
-import { AltVWorldObject, IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
+import { AltVWorldObject, type IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
 import Colshape = AltVServer.Colshape;
 
 export interface IAltVColshapeOptions extends IAltVWorldObjectOptions<Colshape> {}

--- a/src/server/entities/altv/colshape/AltVColshapesManager.ts
+++ b/src/server/entities/altv/colshape/AltVColshapesManager.ts
@@ -1,13 +1,13 @@
 import {
-  ICircleColshapeCreateOptions,
-  IColshapesManager,
-  ICuboidColshapeCreateOptions,
-  ICylinderColshapeCreateOptions,
-  IRectangleColshapeCreateOptions,
-  ISphereColshapeCreateOptions,
+  type ICircleColshapeCreateOptions,
+  type IColshapesManager,
+  type ICuboidColshapeCreateOptions,
+  type ICylinderColshapeCreateOptions,
+  type IRectangleColshapeCreateOptions,
+  type ISphereColshapeCreateOptions,
 } from "../../common";
 import { AltVWorldObjectsManager } from "../worldObject/AltVWorldObjectsManager";
-import { AltVColshape } from "./AltVColshape";
+import { type AltVColshape } from "./AltVColshape";
 import { AltVCircleColshape } from "./AltVCircleColshape";
 import { AltVCuboidColshape } from "./AltVCuboidColshape";
 import { AltVCylinderColshape } from "./AltVCylinderColshape";

--- a/src/server/entities/altv/colshape/AltVCuboidColshape.ts
+++ b/src/server/entities/altv/colshape/AltVCuboidColshape.ts
@@ -1,5 +1,5 @@
-import { ICuboidColshape } from "../../common";
-import { AltVColshape, IAltVColshapeOptions } from "./AltVColshape";
+import { type ICuboidColshape } from "../../common";
+import { AltVColshape, type IAltVColshapeOptions } from "./AltVColshape";
 
 export interface IAltVCuboidColshapeOptions extends IAltVColshapeOptions {}
 

--- a/src/server/entities/altv/colshape/AltVCylinderColshape.ts
+++ b/src/server/entities/altv/colshape/AltVCylinderColshape.ts
@@ -1,5 +1,5 @@
-import { ICylinderColshape } from "../../common";
-import { AltVColshape, IAltVColshapeOptions } from "./AltVColshape";
+import { type ICylinderColshape } from "../../common";
+import { AltVColshape, type IAltVColshapeOptions } from "./AltVColshape";
 
 export interface IAltVCylinderColshapeOptions extends IAltVColshapeOptions {}
 

--- a/src/server/entities/altv/colshape/AltVRectangleColshape.ts
+++ b/src/server/entities/altv/colshape/AltVRectangleColshape.ts
@@ -1,5 +1,5 @@
-import { IRectangleColshape } from "../../common";
-import { AltVColshape, IAltVColshapeOptions } from "./AltVColshape";
+import { type IRectangleColshape } from "../../common";
+import { AltVColshape, type IAltVColshapeOptions } from "./AltVColshape";
 
 export interface IAltVRectangleColshapeOptions extends IAltVColshapeOptions {}
 

--- a/src/server/entities/altv/colshape/AltVSphereColshape.ts
+++ b/src/server/entities/altv/colshape/AltVSphereColshape.ts
@@ -1,5 +1,5 @@
-import { ISphereColshape } from "../../common";
-import { AltVColshape, IAltVColshapeOptions } from "./AltVColshape";
+import { type ISphereColshape } from "../../common";
+import { AltVColshape, type IAltVColshapeOptions } from "./AltVColshape";
 
 export interface IAltVSphereColshapeOptions extends IAltVColshapeOptions {}
 

--- a/src/server/entities/altv/entity/AltVEntitiesManager.ts
+++ b/src/server/entities/altv/entity/AltVEntitiesManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager } from "../../common/entity/IEntitiesManager";
-import { AltVEntity } from "./AltVEntity";
+import { type IEntitiesManager } from "../../common/entity/IEntitiesManager";
+import { type AltVEntity } from "./AltVEntity";
 import { AltVWorldObjectsManager } from "../worldObject/AltVWorldObjectsManager";
 import Entity = AltVServer.Entity;
 

--- a/src/server/entities/altv/entity/AltVEntity.ts
+++ b/src/server/entities/altv/entity/AltVEntity.ts
@@ -1,5 +1,5 @@
-import { IEntity } from "../../common/entity/IEntity";
-import { AltVWorldObject, IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
+import { type IEntity } from "../../common/entity/IEntity";
+import { AltVWorldObject, type IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
 import hash = AltVShared.hash;
 import Entity = AltVServer.Entity;
 import { Vector3D } from "../../../../shared/common/utils";

--- a/src/server/entities/altv/marker/AltVMarker.ts
+++ b/src/server/entities/altv/marker/AltVMarker.ts
@@ -1,9 +1,9 @@
-import { AltVWorldObject, IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
+import { AltVWorldObject, type IAltVWorldObjectOptions } from "../worldObject/AltVWorldObject";
 import Marker = AltVServer.Marker;
-import { IMarker } from "../../common";
+import { type IMarker } from "../../common";
 import Vector3 = AltVShared.Vector3;
-import { IRGBA, IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
-import { IMarkerType } from "../../../../shared";
+import { type IRGBA, type IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
+import { type IMarkerType } from "../../../../shared";
 
 export interface IAltVMarkerOptions extends IAltVWorldObjectOptions<Marker> {}
 

--- a/src/server/entities/altv/marker/AltVMarkersManager.ts
+++ b/src/server/entities/altv/marker/AltVMarkersManager.ts
@@ -1,4 +1,4 @@
-import { IMarkerCreateOptions, IMarkersManager } from "../../common";
+import { type IMarkerCreateOptions, type IMarkersManager } from "../../common";
 import { AltVWorldObjectsManager } from "../worldObject/AltVWorldObjectsManager";
 import { AltVMarker } from "./AltVMarker";
 import alt = AltVServer;

--- a/src/server/entities/altv/object/AltVObject.ts
+++ b/src/server/entities/altv/object/AltVObject.ts
@@ -1,5 +1,5 @@
-import { AltVEntity, IAltVEntityOptions } from "../entity/AltVEntity";
-import { IObject } from "../../common/object/IObject";
+import { AltVEntity, type IAltVEntityOptions } from "../entity/AltVEntity";
+import { type IObject } from "../../common/object/IObject";
 
 export interface IAltVObjectOptions extends IAltVEntityOptions<AltVServer.Object> {}
 

--- a/src/server/entities/altv/object/AltVObjectsManager.ts
+++ b/src/server/entities/altv/object/AltVObjectsManager.ts
@@ -1,4 +1,4 @@
-import { IObjectCreateOptions, IObjectsManager } from "../../common/object/IObjectsManager";
+import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
 import { AltVEntitiesManager } from "../entity/AltVEntitiesManager";
 import { AltVObject } from "./AltVObject";
 import alt = AltVServer;

--- a/src/server/entities/altv/ped/AltVPed.ts
+++ b/src/server/entities/altv/ped/AltVPed.ts
@@ -1,6 +1,6 @@
-import { AltVEntity, IAltVEntityOptions } from "../entity/AltVEntity";
+import { AltVEntity, type IAltVEntityOptions } from "../entity/AltVEntity";
 import Ped = AltVServer.Ped;
-import { IPed } from "../../common";
+import { type IPed } from "../../common";
 
 export interface IAltVPedOptions extends IAltVEntityOptions<Ped> {}
 

--- a/src/server/entities/altv/ped/AltVPedsManager.ts
+++ b/src/server/entities/altv/ped/AltVPedsManager.ts
@@ -1,4 +1,4 @@
-import { IPedCreateOptions, IPedsManager } from "../../common";
+import { type IPedCreateOptions, type IPedsManager } from "../../common";
 import { AltVEntitiesManager } from "../entity/AltVEntitiesManager";
 import { AltVPed } from "./AltVPed";
 import alt = AltVServer;

--- a/src/server/entities/altv/player/AltVPlayer.ts
+++ b/src/server/entities/altv/player/AltVPlayer.ts
@@ -1,15 +1,15 @@
-import { AltVEntity, IAltVEntityOptions } from "../entity/AltVEntity";
-import { ICustomization, IPlayer } from "../../common/player/IPlayer";
-import { AltVVehicle } from "../vehicle/AltVVehicle";
+import { AltVEntity, type IAltVEntityOptions } from "../entity/AltVEntity";
+import { type ICustomization, type IPlayer } from "../../common/player/IPlayer";
+import { type AltVVehicle } from "../vehicle/AltVVehicle";
 import { RockMod } from "../../../RockMod";
 import Player = AltVServer.Player;
 import Vehicle = AltVServer.Vehicle;
 import Vector3 = AltVShared.Vector3;
 import hash = AltVShared.hash;
-import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
-import { IAltVClientRPC } from "../../../net/altv/rpc/AltVRPCManager";
+import { type Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IAltVClientRPC } from "../../../net/altv/rpc/AltVRPCManager";
 import { MathClamp } from "../../../../shared/common/utils/math/Math";
-import { IServerToClientEvents } from "../../../../shared";
+import { type IServerToClientEvents } from "../../../../shared";
 
 interface AltVPlayerOptions extends IAltVEntityOptions<Player> {}
 

--- a/src/server/entities/altv/player/AltVPlayersManager.ts
+++ b/src/server/entities/altv/player/AltVPlayersManager.ts
@@ -1,6 +1,6 @@
 import { AltVEntitiesManager } from "../entity/AltVEntitiesManager";
-import { AltVPlayer } from "./AltVPlayer";
-import { IPlayersManager } from "../../common/player/IPlayersManager";
+import { type AltVPlayer } from "./AltVPlayer";
+import { type IPlayersManager } from "../../common/player/IPlayersManager";
 
 export class AltVPlayersManager extends AltVEntitiesManager<AltVPlayer> implements IPlayersManager {
   public constructor() {

--- a/src/server/entities/altv/vehicle/AltVVehicle.ts
+++ b/src/server/entities/altv/vehicle/AltVVehicle.ts
@@ -1,9 +1,9 @@
-import { AltVEntity, IAltVEntityOptions } from "../entity/AltVEntity";
-import { IVehicle } from "../../common/vehicle/IVehicle";
+import { AltVEntity, type IAltVEntityOptions } from "../entity/AltVEntity";
+import { type IVehicle } from "../../common/vehicle/IVehicle";
 import Vehicle = AltVServer.Vehicle;
 import VehicleLockState = AltVShared.VehicleLockState;
 import { RGBA } from "../../../../shared/common/utils";
-import { AltVPlayer } from "../player/AltVPlayer";
+import { type AltVPlayer } from "../player/AltVPlayer";
 import { RockMod } from "../../../RockMod";
 
 export interface IAltVVehicleOptions extends IAltVEntityOptions<Vehicle> {}

--- a/src/server/entities/altv/vehicle/AltVVehiclesManager.ts
+++ b/src/server/entities/altv/vehicle/AltVVehiclesManager.ts
@@ -1,7 +1,7 @@
 import { AltVEntitiesManager } from "../entity/AltVEntitiesManager";
 import { AltVVehicle } from "./AltVVehicle";
-import { IVehicleCreateOptions, IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
-import { IVehicle } from "../../common/vehicle/IVehicle";
+import { type IVehicleCreateOptions, type IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
+import { type IVehicle } from "../../common/vehicle/IVehicle";
 import alt = AltVServer;
 
 export interface IAltVVehicleCreateOptions extends IVehicleCreateOptions {}

--- a/src/server/entities/altv/worldObject/AltVWorldObject.ts
+++ b/src/server/entities/altv/worldObject/AltVWorldObject.ts
@@ -1,6 +1,6 @@
-import { IWorldObject } from "../../common/worldObject/IWorldObject";
+import { type IWorldObject } from "../../common/worldObject/IWorldObject";
 import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
-import { AltVBaseObject, IAltVBaseObjectOptions } from "../baseObject/AltVBaseObject";
+import { AltVBaseObject, type IAltVBaseObjectOptions } from "../baseObject/AltVBaseObject";
 import WorldObject = AltVServer.WorldObject;
 import Vector3 = AltVShared.Vector3;
 

--- a/src/server/entities/altv/worldObject/AltVWorldObjectsIterator.ts
+++ b/src/server/entities/altv/worldObject/AltVWorldObjectsIterator.ts
@@ -1,7 +1,7 @@
-import { IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
-import { AltVWorldObject } from "./AltVWorldObject";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { type AltVWorldObject } from "./AltVWorldObject";
 import { AltVBaseObjectsIterator } from "../baseObject/AltVBaseObjectsIterator";
-import { Vector2D, Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type Vector2D, type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 import WorldObject = AltVServer.WorldObject;
 
 export class AltVWorldObjectsIterator<T extends AltVWorldObject<WorldObject>>

--- a/src/server/entities/altv/worldObject/AltVWorldObjectsManager.ts
+++ b/src/server/entities/altv/worldObject/AltVWorldObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IWorldObjectsManager } from "../../common/worldObject/IWorldObjectsManager";
-import { AltVWorldObject } from "./AltVWorldObject";
-import { AltVBaseObjectsManager, IAltVBaseObjectsManagerOptions } from "../baseObject/AltVBaseObjectsManager";
+import { type IWorldObjectsManager } from "../../common/worldObject/IWorldObjectsManager";
+import { type AltVWorldObject } from "./AltVWorldObject";
+import { AltVBaseObjectsManager, type IAltVBaseObjectsManagerOptions } from "../baseObject/AltVBaseObjectsManager";
 import { AltVWorldObjectsIterator } from "./AltVWorldObjectsIterator";
 import WorldObject = AltVServer.WorldObject;
 

--- a/src/server/entities/common/baseObject/IBaseObject.ts
+++ b/src/server/entities/common/baseObject/IBaseObject.ts
@@ -1,5 +1,5 @@
 import BaseObject = AltVServer.BaseObject;
-import { BaseObjectType } from "../../../../shared";
+import { type BaseObjectType } from "../../../../shared";
 
 export interface IBaseObjectOptions {
   mpEntity: EntityMp | BaseObject;

--- a/src/server/entities/common/baseObject/IBaseObjectsIterator.ts
+++ b/src/server/entities/common/baseObject/IBaseObjectsIterator.ts
@@ -1,4 +1,4 @@
-import { IBaseObject } from "./IBaseObject";
+import { type IBaseObject } from "./IBaseObject";
 
 export interface IBaseObjectsIterator<T extends IBaseObject> {
   all(): IterableIterator<T>;

--- a/src/server/entities/common/baseObject/IBaseObjectsManager.ts
+++ b/src/server/entities/common/baseObject/IBaseObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IBaseObject } from "./IBaseObject";
-import { IBaseObjectsIterator } from "./IBaseObjectsIterator";
-import { BaseObjectType } from "../../../../shared";
+import { type IBaseObject } from "./IBaseObject";
+import { type IBaseObjectsIterator } from "./IBaseObjectsIterator";
+import { type BaseObjectType } from "../../../../shared";
 
 export interface IBaseObjectsManagerOptions {
   baseObjectsType: `${BaseObjectType}`;

--- a/src/server/entities/common/blip/IBlip.ts
+++ b/src/server/entities/common/blip/IBlip.ts
@@ -1,5 +1,5 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
-import { IBlipColor, IBlipSprite } from "../../../../shared";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
+import { type IBlipColor, type IBlipSprite } from "../../../../shared";
 
 export interface IBlipOptions extends IWorldObjectOptions {}
 

--- a/src/server/entities/common/blip/IBlipsManager.ts
+++ b/src/server/entities/common/blip/IBlipsManager.ts
@@ -1,5 +1,5 @@
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IBlip } from "./IBlip";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IBlip } from "./IBlip";
 
 export interface IBlipCreateOptions extends IWorldObjectCreateOptions {
   alpha?: number;

--- a/src/server/entities/common/colshape/ICircleColshape.ts
+++ b/src/server/entities/common/colshape/ICircleColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICircleColshapeOptions extends IColshapeOptions {}
 

--- a/src/server/entities/common/colshape/IColshape.ts
+++ b/src/server/entities/common/colshape/IColshape.ts
@@ -1,4 +1,4 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
 
 export interface IColshapeOptions extends IWorldObjectOptions {}
 

--- a/src/server/entities/common/colshape/IColshapesManager.ts
+++ b/src/server/entities/common/colshape/IColshapesManager.ts
@@ -1,11 +1,11 @@
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IColshape } from "./IColshape";
-import { IVector2D } from "../../../../shared/common/utils";
-import { ICircleColshape } from "./ICircleColshape";
-import { ICuboidColshape } from "./ICuboidColshape";
-import { ICylinderColshape } from "./ICylinderColshape";
-import { IRectangleColshape } from "./IRectangleColshape";
-import { ISphereColshape } from "./ISphereColshape";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IColshape } from "./IColshape";
+import { type IVector2D } from "../../../../shared/common/utils";
+import { type ICircleColshape } from "./ICircleColshape";
+import { type ICuboidColshape } from "./ICuboidColshape";
+import { type ICylinderColshape } from "./ICylinderColshape";
+import { type IRectangleColshape } from "./IRectangleColshape";
+import { type ISphereColshape } from "./ISphereColshape";
 
 export interface ICircleColshapeCreateOptions extends Omit<IWorldObjectCreateOptions, "position"> {
   position: IVector2D;

--- a/src/server/entities/common/colshape/ICuboidColshape.ts
+++ b/src/server/entities/common/colshape/ICuboidColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICuboidColshapeOptions extends IColshapeOptions {}
 

--- a/src/server/entities/common/colshape/ICylinderColshape.ts
+++ b/src/server/entities/common/colshape/ICylinderColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ICylinderColshapeOptions extends IColshapeOptions {}
 

--- a/src/server/entities/common/colshape/IRectangleColshape.ts
+++ b/src/server/entities/common/colshape/IRectangleColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface IRectangleColshapeOptions extends IColshapeOptions {}
 

--- a/src/server/entities/common/colshape/ISphereColshape.ts
+++ b/src/server/entities/common/colshape/ISphereColshape.ts
@@ -1,4 +1,4 @@
-import { IColshape, IColshapeOptions } from "./IColshape";
+import { type IColshape, type IColshapeOptions } from "./IColshape";
 
 export interface ISphereColshapeOptions extends IColshapeOptions {}
 

--- a/src/server/entities/common/entity/IEntitiesManager.ts
+++ b/src/server/entities/common/entity/IEntitiesManager.ts
@@ -1,10 +1,10 @@
 import {
-  IWorldObjectCreateOptions,
-  IWorldObjectsManager,
-  IWorldObjectsManagerOptions,
+  type IWorldObjectCreateOptions,
+  type IWorldObjectsManager,
+  type IWorldObjectsManagerOptions,
 } from "../worldObject/IWorldObjectsManager";
-import { IEntity } from "./IEntity";
-import { IVector3D } from "../../../../shared/common/utils";
+import { type IEntity } from "./IEntity";
+import { type IVector3D } from "../../../../shared/common/utils";
 
 export interface IEntitiesManagerOptions extends IWorldObjectsManagerOptions {}
 

--- a/src/server/entities/common/entity/IEntity.ts
+++ b/src/server/entities/common/entity/IEntity.ts
@@ -1,5 +1,5 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject/IWorldObject";
-import { IVector3D } from "../../../../shared/common/utils";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject/IWorldObject";
+import { type IVector3D } from "../../../../shared/common/utils";
 
 export interface IEntityOptions extends IWorldObjectOptions {}
 

--- a/src/server/entities/common/marker/IMarker.ts
+++ b/src/server/entities/common/marker/IMarker.ts
@@ -1,6 +1,6 @@
-import { IWorldObject, IWorldObjectOptions } from "../worldObject";
-import { IRGBA, IVector3D } from "../../../../shared/common/utils";
-import { IMarkerType } from "../../../../shared";
+import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
+import { type IRGBA, type IVector3D } from "../../../../shared/common/utils";
+import { type IMarkerType } from "../../../../shared";
 
 export interface IMarkerOptions extends IWorldObjectOptions {
   type: IMarkerType;

--- a/src/server/entities/common/marker/IMarkersManager.ts
+++ b/src/server/entities/common/marker/IMarkersManager.ts
@@ -1,7 +1,7 @@
-import { IMarker } from "./IMarker";
-import { IWorldObjectCreateOptions, IWorldObjectsManager } from "../worldObject";
-import { IRGBA, IVector3D } from "../../../../shared/common/utils";
-import { IMarkerType } from "../../../../shared";
+import { type IMarker } from "./IMarker";
+import { type IWorldObjectCreateOptions, type IWorldObjectsManager } from "../worldObject";
+import { type IRGBA, type IVector3D } from "../../../../shared/common/utils";
+import { type IMarkerType } from "../../../../shared";
 
 export interface IMarkerCreateOptions extends IWorldObjectCreateOptions {
   type: IMarkerType;

--- a/src/server/entities/common/object/IObject.ts
+++ b/src/server/entities/common/object/IObject.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity";
+import { type IEntity, type IEntityOptions } from "../entity";
 
 export interface IObjectOptions extends IEntityOptions {}
 

--- a/src/server/entities/common/object/IObjectsManager.ts
+++ b/src/server/entities/common/object/IObjectsManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity";
-import { IObject } from "./IObject";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity";
+import { type IObject } from "./IObject";
 
 export interface IObjectCreateOptions extends IEntityCreateOptions {
   alpha: number;

--- a/src/server/entities/common/ped/IPed.ts
+++ b/src/server/entities/common/ped/IPed.ts
@@ -1,4 +1,4 @@
-import { IEntity, IEntityOptions } from "../entity";
+import { type IEntity, type IEntityOptions } from "../entity";
 
 export interface IPedOptions extends IEntityOptions {}
 

--- a/src/server/entities/common/ped/IPedsManager.ts
+++ b/src/server/entities/common/ped/IPedsManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity";
-import { IPed } from "./IPed";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity";
+import { type IPed } from "./IPed";
 
 export interface IPedCreateOptions extends IEntityCreateOptions {
   frozen: boolean;

--- a/src/server/entities/common/player/IPlayer.ts
+++ b/src/server/entities/common/player/IPlayer.ts
@@ -1,8 +1,8 @@
-import { IEntity, IEntityOptions } from "../entity/IEntity";
-import { IVehicle } from "../vehicle/IVehicle";
-import { IVector3D } from "../../../../shared/common/utils/math/Vectors";
-import { IServerToClientEvents } from "../../../../shared";
-import { IClientRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IEntity, type IEntityOptions } from "../entity/IEntity";
+import { type IVehicle } from "../vehicle/IVehicle";
+import { type IVector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IServerToClientEvents } from "../../../../shared";
+import { type IClientRPCList } from "../../../../shared/net/common/rpc/types";
 
 export interface ICustomization {
   gender: boolean;

--- a/src/server/entities/common/player/IPlayersManager.ts
+++ b/src/server/entities/common/player/IPlayersManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager } from "../entity/IEntitiesManager";
-import { IPlayer } from "./IPlayer";
+import { type IEntitiesManager } from "../entity/IEntitiesManager";
+import { type IPlayer } from "./IPlayer";
 
 export interface IPlayersManager extends IEntitiesManager<IPlayer> {
   getByName(name: string): IPlayer;

--- a/src/server/entities/common/vehicle/IVehicle.ts
+++ b/src/server/entities/common/vehicle/IVehicle.ts
@@ -1,6 +1,6 @@
-import { IEntity, IEntityOptions } from "../entity/IEntity";
-import { IRGBA } from "../../../../shared/common/utils";
-import { IPlayer } from "../player";
+import { type IEntity, type IEntityOptions } from "../entity/IEntity";
+import { type IRGBA } from "../../../../shared/common/utils";
+import { type IPlayer } from "../player";
 
 export enum VehicleSeat {
   NONE = 255,

--- a/src/server/entities/common/vehicle/IVehiclesManager.ts
+++ b/src/server/entities/common/vehicle/IVehiclesManager.ts
@@ -1,5 +1,5 @@
-import { IEntitiesManager, IEntityCreateOptions } from "../entity/IEntitiesManager";
-import { IVehicle } from "./IVehicle";
+import { type IEntitiesManager, type IEntityCreateOptions } from "../entity/IEntitiesManager";
+import { type IVehicle } from "./IVehicle";
 
 export interface IVehicleCreateOptions extends IEntityCreateOptions {
   engine: boolean;

--- a/src/server/entities/common/worldObject/IWorldObject.ts
+++ b/src/server/entities/common/worldObject/IWorldObject.ts
@@ -1,5 +1,5 @@
-import { IBaseObject, IBaseObjectOptions } from "../baseObject";
-import { IVector3D } from "../../../../shared/common/utils";
+import { type IBaseObject, type IBaseObjectOptions } from "../baseObject";
+import { type IVector3D } from "../../../../shared/common/utils";
 
 export interface IWorldObjectOptions extends IBaseObjectOptions {}
 

--- a/src/server/entities/common/worldObject/IWorldObjectsIterator.ts
+++ b/src/server/entities/common/worldObject/IWorldObjectsIterator.ts
@@ -1,6 +1,6 @@
-import { IBaseObjectsIterator } from "../baseObject/IBaseObjectsIterator";
-import { IWorldObject } from "./IWorldObject";
-import { Vector2D, Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IBaseObjectsIterator } from "../baseObject/IBaseObjectsIterator";
+import { type IWorldObject } from "./IWorldObject";
+import { type Vector2D, type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export interface IWorldObjectsIterator<T extends IWorldObject> extends IBaseObjectsIterator<T> {
   dimension(value: number): IterableIterator<T>;

--- a/src/server/entities/common/worldObject/IWorldObjectsManager.ts
+++ b/src/server/entities/common/worldObject/IWorldObjectsManager.ts
@@ -1,7 +1,11 @@
-import { IBaseObjectCreateOptions, IBaseObjectsManager, IBaseObjectsManagerOptions } from "../baseObject";
-import { IWorldObject } from "./IWorldObject";
-import { IWorldObjectsIterator } from "./IWorldObjectsIterator";
-import { IVector3D } from "../../../../shared/common/utils";
+import {
+  type IBaseObjectCreateOptions,
+  type IBaseObjectsManager,
+  type IBaseObjectsManagerOptions,
+} from "../baseObject";
+import { type IWorldObject } from "./IWorldObject";
+import { type IWorldObjectsIterator } from "./IWorldObjectsIterator";
+import { type IVector3D } from "../../../../shared/common/utils";
 
 export interface IWorldObjectsManagerOptions extends IBaseObjectsManagerOptions {}
 

--- a/src/server/entities/mock/baseObject/MockBaseObject.ts
+++ b/src/server/entities/mock/baseObject/MockBaseObject.ts
@@ -1,6 +1,6 @@
-import { IBaseObject } from "../../common/baseObject/IBaseObject";
-import { IVector3D } from "../../../../shared/common/utils/math/Vectors";
-import { BaseObjectType } from "../../../../shared";
+import { type IBaseObject } from "../../common/baseObject/IBaseObject";
+import { type IVector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type BaseObjectType } from "../../../../shared";
 
 export interface IMockBaseObjectOptions {
   id: number;

--- a/src/server/entities/mock/baseObject/MockBaseObjectsIterator.ts
+++ b/src/server/entities/mock/baseObject/MockBaseObjectsIterator.ts
@@ -1,5 +1,5 @@
-import { IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
-import { MockBaseObject } from "./MockBaseObject";
+import { type IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
+import { type MockBaseObject } from "./MockBaseObject";
 
 export class MockBaseObjectsIterator<T extends MockBaseObject> implements IBaseObjectsIterator<T> {
   protected readonly _baseObjects: ReadonlyMap<number, T>;

--- a/src/server/entities/mock/baseObject/MockBaseObjectsManager.ts
+++ b/src/server/entities/mock/baseObject/MockBaseObjectsManager.ts
@@ -1,8 +1,8 @@
-import { IBaseObjectsManager, IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
-import { MockBaseObject } from "./MockBaseObject";
+import { type IBaseObjectsManager, type IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
+import { type MockBaseObject } from "./MockBaseObject";
 import { MockBaseObjectsIterator } from "./MockBaseObjectsIterator";
 import { RockMod } from "../../../RockMod";
-import { BaseObjectType } from "../../../../shared";
+import { type BaseObjectType } from "../../../../shared";
 import { ServerInternalEventName } from "../../../net/common/events/types";
 
 export interface IMockBaseObjectsManagerOptions extends IBaseObjectsManagerOptions {}

--- a/src/server/entities/mock/blip/MockBlip.ts
+++ b/src/server/entities/mock/blip/MockBlip.ts
@@ -1,6 +1,6 @@
-import { MockWorldObject, IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
-import { IBlip } from "../../common";
-import { IBlipColor, IBlipSprite } from "../../../../shared";
+import { MockWorldObject, type IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
+import { type IBlip } from "../../common";
+import { type IBlipColor, type IBlipSprite } from "../../../../shared";
 
 export interface IMockBlipOptions extends IMockWorldObjectOptions {
   alpha: number;

--- a/src/server/entities/mock/blip/MockBlipsManager.ts
+++ b/src/server/entities/mock/blip/MockBlipsManager.ts
@@ -1,4 +1,4 @@
-import { IBlipCreateOptions, IBlipsManager } from "../../common/blip/IBlipsManager";
+import { type IBlipCreateOptions, type IBlipsManager } from "../../common/blip/IBlipsManager";
 import { MockWorldObjectsManager } from "../worldObject/MockWorldObjectsManager";
 import { MockBlip } from "./MockBlip";
 import { BaseObjectType } from "../../../../shared";

--- a/src/server/entities/mock/colshape/MockCircleColshape.ts
+++ b/src/server/entities/mock/colshape/MockCircleColshape.ts
@@ -1,5 +1,5 @@
-import { ICircleColshape } from "../../common";
-import { IMockColshapeOptions, MockColshape } from "./MockColshape";
+import { type ICircleColshape } from "../../common";
+import { type IMockColshapeOptions, MockColshape } from "./MockColshape";
 
 export interface IMockCircleColshapeCreateOptions extends IMockColshapeOptions {
   range: number;

--- a/src/server/entities/mock/colshape/MockColshape.ts
+++ b/src/server/entities/mock/colshape/MockColshape.ts
@@ -1,5 +1,5 @@
-import { IColshape } from "../../common/colshape/IColshape";
-import { MockWorldObject, IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
+import { type IColshape } from "../../common/colshape/IColshape";
+import { MockWorldObject, type IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
 
 export interface IMockColshapeOptions extends IMockWorldObjectOptions {}
 

--- a/src/server/entities/mock/colshape/MockColshapesManager.ts
+++ b/src/server/entities/mock/colshape/MockColshapesManager.ts
@@ -1,10 +1,10 @@
 import {
-  ICircleColshapeCreateOptions,
-  IColshapesManager,
-  ICuboidColshapeCreateOptions,
-  ICylinderColshapeCreateOptions,
-  IRectangleColshapeCreateOptions,
-  ISphereColshapeCreateOptions,
+  type ICircleColshapeCreateOptions,
+  type IColshapesManager,
+  type ICuboidColshapeCreateOptions,
+  type ICylinderColshapeCreateOptions,
+  type IRectangleColshapeCreateOptions,
+  type ISphereColshapeCreateOptions,
 } from "../../common";
 import { MockWorldObjectsManager } from "../worldObject/MockWorldObjectsManager";
 import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
@@ -13,7 +13,7 @@ import { MockCuboidColshape } from "./MockCuboidColshape";
 import { MockCylinderColshape } from "./MockCylinderColshape";
 import { MockRectangleColshape } from "./MockRectangleColshape";
 import { MockSphereColshape } from "./MockSphereColshape";
-import { MockColshape } from "./MockColshape";
+import { type MockColshape } from "./MockColshape";
 import { BaseObjectType } from "../../../../shared";
 
 export interface IMockCircleColshapeCreateOptions extends ICircleColshapeCreateOptions {}

--- a/src/server/entities/mock/colshape/MockCuboidColshape.ts
+++ b/src/server/entities/mock/colshape/MockCuboidColshape.ts
@@ -1,5 +1,5 @@
-import { ICuboidColshape } from "../../common";
-import { IMockColshapeOptions, MockColshape } from "./MockColshape";
+import { type ICuboidColshape } from "../../common";
+import { type IMockColshapeOptions, MockColshape } from "./MockColshape";
 
 export interface IMockCuboidColshapeCreateOptions extends IMockColshapeOptions {
   width: number;

--- a/src/server/entities/mock/colshape/MockCylinderColshape.ts
+++ b/src/server/entities/mock/colshape/MockCylinderColshape.ts
@@ -1,5 +1,5 @@
-import { ICylinderColshape } from "../../common";
-import { IMockColshapeOptions, MockColshape } from "./MockColshape";
+import { type ICylinderColshape } from "../../common";
+import { type IMockColshapeOptions, MockColshape } from "./MockColshape";
 
 export interface IMockCylinderColshapeCreateOptions extends IMockColshapeOptions {
   height: number;

--- a/src/server/entities/mock/colshape/MockRectangleColshape.ts
+++ b/src/server/entities/mock/colshape/MockRectangleColshape.ts
@@ -1,5 +1,5 @@
-import { IRectangleColshape } from "../../common";
-import { IMockColshapeOptions, MockColshape } from "./MockColshape";
+import { type IRectangleColshape } from "../../common";
+import { type IMockColshapeOptions, MockColshape } from "./MockColshape";
 
 export interface IMockRectangleColshapeCreateOptions extends IMockColshapeOptions {
   width: number;

--- a/src/server/entities/mock/colshape/MockSphereColshape.ts
+++ b/src/server/entities/mock/colshape/MockSphereColshape.ts
@@ -1,5 +1,5 @@
-import { ISphereColshape } from "../../common";
-import { IMockColshapeOptions, MockColshape } from "./MockColshape";
+import { type ISphereColshape } from "../../common";
+import { type IMockColshapeOptions, MockColshape } from "./MockColshape";
 
 export interface IMockSphereColshapeCreateOptions extends IMockColshapeOptions {
   range: number;

--- a/src/server/entities/mock/common/IMockEntity.ts
+++ b/src/server/entities/mock/common/IMockEntity.ts
@@ -1,4 +1,4 @@
-import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export interface IMockEntity {
   id: number;

--- a/src/server/entities/mock/entity/MockEntitiesManager.ts
+++ b/src/server/entities/mock/entity/MockEntitiesManager.ts
@@ -1,6 +1,6 @@
-import { IEntitiesManager } from "../../common/entity/IEntitiesManager";
-import { MockEntity } from "./MockEntity";
-import { IMockWorldObjectsManagerOptions, MockWorldObjectsManager } from "../worldObject/MockWorldObjectsManager";
+import { type IEntitiesManager } from "../../common/entity/IEntitiesManager";
+import { type MockEntity } from "./MockEntity";
+import { type IMockWorldObjectsManagerOptions, MockWorldObjectsManager } from "../worldObject/MockWorldObjectsManager";
 
 export interface IMockEntitiesManagerOptions extends IMockWorldObjectsManagerOptions {}
 

--- a/src/server/entities/mock/entity/MockEntity.ts
+++ b/src/server/entities/mock/entity/MockEntity.ts
@@ -1,6 +1,6 @@
-import { IEntity } from "../../common/entity/IEntity";
-import { MockWorldObject, IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
-import { IVector3D, Vector3D } from "../../../../shared/common/utils";
+import { type IEntity } from "../../common/entity/IEntity";
+import { MockWorldObject, type IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
+import { type IVector3D, Vector3D } from "../../../../shared/common/utils";
 import { RockMod } from "../../../RockMod";
 
 export interface IMockEntityOptions extends IMockWorldObjectOptions {

--- a/src/server/entities/mock/marker/MockMarker.ts
+++ b/src/server/entities/mock/marker/MockMarker.ts
@@ -1,6 +1,6 @@
-import { IMarker } from "../../common/marker/IMarker";
-import { MockWorldObject, IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
-import { IRGBA, IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
+import { type IMarker } from "../../common/marker/IMarker";
+import { MockWorldObject, type IMockWorldObjectOptions } from "../worldObject/MockWorldObject";
+import { type IRGBA, type IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
 import { IMarkerType } from "../../../../shared";
 
 export interface IMockMarkerOptions extends IMockWorldObjectOptions {

--- a/src/server/entities/mock/marker/MockMarkersManager.ts
+++ b/src/server/entities/mock/marker/MockMarkersManager.ts
@@ -1,4 +1,4 @@
-import { IMarkerCreateOptions, IMarkersManager } from "../../common/marker/IMarkersManager";
+import { type IMarkerCreateOptions, type IMarkersManager } from "../../common/marker/IMarkersManager";
 import { MockWorldObjectsManager } from "../worldObject/MockWorldObjectsManager";
 import { MockMarker } from "./MockMarker";
 import { BaseObjectType } from "../../../../shared";

--- a/src/server/entities/mock/object/MockObject.ts
+++ b/src/server/entities/mock/object/MockObject.ts
@@ -1,5 +1,5 @@
-import { IObject } from "../../common/object/IObject";
-import { MockEntity, IMockEntityOptions } from "../entity/MockEntity";
+import { type IObject } from "../../common/object/IObject";
+import { MockEntity, type IMockEntityOptions } from "../entity/MockEntity";
 
 export interface IMockObjectOptions extends IMockEntityOptions {
   alpha?: number;

--- a/src/server/entities/mock/object/MockObjectsManager.ts
+++ b/src/server/entities/mock/object/MockObjectsManager.ts
@@ -1,4 +1,4 @@
-import { IObjectCreateOptions, IObjectsManager } from "../../common/object/IObjectsManager";
+import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
 import { MockEntitiesManager } from "../entity/MockEntitiesManager";
 import { MockObject } from "./MockObject";
 import { RockMod } from "../../../RockMod";

--- a/src/server/entities/mock/ped/MockPed.ts
+++ b/src/server/entities/mock/ped/MockPed.ts
@@ -1,5 +1,5 @@
-import { IPed } from "../../common/ped/IPed";
-import { MockEntity, IMockEntityOptions } from "../entity/MockEntity";
+import { type IPed } from "../../common/ped/IPed";
+import { MockEntity, type IMockEntityOptions } from "../entity/MockEntity";
 
 export interface IMockPedOptions extends IMockEntityOptions {}
 

--- a/src/server/entities/mock/ped/MockPedsManager.ts
+++ b/src/server/entities/mock/ped/MockPedsManager.ts
@@ -1,4 +1,4 @@
-import { IPedCreateOptions, IPedsManager } from "../../common/ped/IPedsManager";
+import { type IPedCreateOptions, type IPedsManager } from "../../common/ped/IPedsManager";
 import { MockEntitiesManager } from "../entity/MockEntitiesManager";
 import { MockPed } from "./MockPed";
 import { RockMod } from "../../../RockMod";

--- a/src/server/entities/mock/player/MockPlayer.ts
+++ b/src/server/entities/mock/player/MockPlayer.ts
@@ -1,11 +1,11 @@
-import { IPlayer } from "../../common/player/IPlayer";
-import { MockEntity, IMockEntityOptions } from "../entity/MockEntity";
-import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IPlayer } from "../../common/player/IPlayer";
+import { MockEntity, type IMockEntityOptions } from "../entity/MockEntity";
+import { type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 import { RockMod } from "../../../RockMod";
-import { RageVehicle } from "../../ragemp/vehicle/RageVehicle";
-import { IMockClientRPC } from "../../../net/mock/rpc/MockRPCManager";
+import { type RageVehicle } from "../../ragemp/vehicle/RageVehicle";
+import { type IMockClientRPC } from "../../../net/mock/rpc/MockRPCManager";
 import { MathClamp } from "../../../../shared/common/utils/math/Math";
-import { IServerToClientEvents } from "../../../../shared";
+import { type IServerToClientEvents } from "../../../../shared";
 
 export interface IMockPlayerOptions extends IMockEntityOptions {
   name?: string;

--- a/src/server/entities/mock/player/MockPlayersManager.ts
+++ b/src/server/entities/mock/player/MockPlayersManager.ts
@@ -1,4 +1,4 @@
-import { IPlayersManager } from "../../common/player/IPlayersManager";
+import { type IPlayersManager } from "../../common/player/IPlayersManager";
 import { MockPlayer } from "./MockPlayer";
 import { MockEntitiesManager } from "../entity/MockEntitiesManager";
 import { RockMod } from "../../../RockMod";

--- a/src/server/entities/mock/vehicle/MockVehicle.ts
+++ b/src/server/entities/mock/vehicle/MockVehicle.ts
@@ -1,7 +1,7 @@
-import { IVehicle } from "../../common/vehicle/IVehicle";
-import { MockEntity, IMockEntityOptions } from "../entity/MockEntity";
-import { IRGBA, RGBA } from "../../../../shared/common/utils";
-import { MockPlayer } from "../player/MockPlayer";
+import { type IVehicle } from "../../common/vehicle/IVehicle";
+import { MockEntity, type IMockEntityOptions } from "../entity/MockEntity";
+import { type IRGBA, RGBA } from "../../../../shared/common/utils";
+import { type MockPlayer } from "../player/MockPlayer";
 import { MathClamp } from "../../../../shared/common/utils/math/Math";
 
 export interface IMockVehicleOptions extends IMockEntityOptions {

--- a/src/server/entities/mock/vehicle/MockVehiclesManager.ts
+++ b/src/server/entities/mock/vehicle/MockVehiclesManager.ts
@@ -1,4 +1,4 @@
-import { IVehicleCreateOptions, IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
+import { type IVehicleCreateOptions, type IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
 import { MockEntitiesManager } from "../entity/MockEntitiesManager";
 import { MockVehicle } from "./MockVehicle";
 import { RockMod } from "../../../RockMod";

--- a/src/server/entities/mock/worldObject/MockWorldObject.ts
+++ b/src/server/entities/mock/worldObject/MockWorldObject.ts
@@ -1,6 +1,6 @@
-import { IWorldObject } from "../../common/worldObject/IWorldObject";
-import { MockBaseObject, IMockBaseObjectOptions } from "../baseObject/MockBaseObject";
-import { IVector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IWorldObject } from "../../common/worldObject/IWorldObject";
+import { MockBaseObject, type IMockBaseObjectOptions } from "../baseObject/MockBaseObject";
+import { type IVector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export interface IMockWorldObjectOptions extends IMockBaseObjectOptions {
   position: IVector3D;

--- a/src/server/entities/mock/worldObject/MockWorldObjectsIterator.ts
+++ b/src/server/entities/mock/worldObject/MockWorldObjectsIterator.ts
@@ -1,7 +1,7 @@
-import { IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
-import { MockWorldObject } from "./MockWorldObject";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { type MockWorldObject } from "./MockWorldObject";
 import { MockBaseObjectsIterator } from "../baseObject/MockBaseObjectsIterator";
-import { Vector2D, Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type Vector2D, type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export class MockWorldObjectsIterator<T extends MockWorldObject>
   extends MockBaseObjectsIterator<T>

--- a/src/server/entities/mock/worldObject/MockWorldObjectsManager.ts
+++ b/src/server/entities/mock/worldObject/MockWorldObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IWorldObjectsManager } from "../../common/worldObject/IWorldObjectsManager";
-import { MockWorldObject } from "./MockWorldObject";
-import { IMockBaseObjectsManagerOptions, MockBaseObjectsManager } from "../baseObject/MockBaseObjectsManager";
+import { type IWorldObjectsManager } from "../../common/worldObject/IWorldObjectsManager";
+import { type MockWorldObject } from "./MockWorldObject";
+import { type IMockBaseObjectsManagerOptions, MockBaseObjectsManager } from "../baseObject/MockBaseObjectsManager";
 import { MockWorldObjectsIterator } from "./MockWorldObjectsIterator";
 
 export interface IMockWorldObjectsManagerOptions extends IMockBaseObjectsManagerOptions {}

--- a/src/server/entities/ragemp/baseObject/RageBaseObject.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObject.ts
@@ -2,7 +2,7 @@ import { type IBaseObject, type IBaseObjectOptions } from "../../common/baseObje
 import { type BaseObjectType } from "../../../../shared";
 
 // RAGEMP BUG: event 'entityDestroyed' is not callable
-const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object", "vehicle"]);
+const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object", "ped", "vehicle"]);
 
 export interface IRageBaseObjectOptions<T extends EntityMp> extends IBaseObjectOptions {
   mpEntity: T;

--- a/src/server/entities/ragemp/baseObject/RageBaseObject.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObject.ts
@@ -1,5 +1,5 @@
-import { IBaseObject, IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
-import { BaseObjectType } from "../../../../shared";
+import { type IBaseObject, type IBaseObjectOptions } from "../../common/baseObject/IBaseObject";
+import { type BaseObjectType } from "../../../../shared";
 
 // RAGEMP BUG: event 'entityDestroyed' is not callable
 const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object", "vehicle"]);

--- a/src/server/entities/ragemp/baseObject/RageBaseObjectsIterator.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObjectsIterator.ts
@@ -1,5 +1,5 @@
-import { IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
-import { RageBaseObject } from "./RageBaseObject";
+import { type IBaseObjectsIterator } from "../../common/baseObject/IBaseObjectsIterator";
+import { type RageBaseObject } from "./RageBaseObject";
 
 export class RageBaseObjectsIterator<T extends RageBaseObject> implements IBaseObjectsIterator<T> {
   private readonly _baseObjects: ReadonlyMap<number, T>;

--- a/src/server/entities/ragemp/baseObject/RageBaseObjectsManager.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObjectsManager.ts
@@ -1,8 +1,8 @@
-import { IBaseObjectsManager, IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
-import { RageBaseObject } from "./RageBaseObject";
+import { type IBaseObjectsManager, type IBaseObjectsManagerOptions } from "../../common/baseObject/IBaseObjectsManager";
+import { type RageBaseObject } from "./RageBaseObject";
 import { RageBaseObjectsIterator } from "./RageBaseObjectsIterator";
 import { RockMod } from "../../../RockMod";
-import { BaseObjectType } from "../../../../shared";
+import { type BaseObjectType } from "../../../../shared";
 import { ServerInternalEventName } from "../../../net/common/events/types";
 
 export interface IRageBaseObjectsManagerOptions extends IBaseObjectsManagerOptions {}

--- a/src/server/entities/ragemp/blip/RageBlip.ts
+++ b/src/server/entities/ragemp/blip/RageBlip.ts
@@ -1,6 +1,6 @@
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
-import { IBlip } from "../../common";
-import { IBlipColor, IBlipSprite } from "../../../../shared";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IBlip } from "../../common";
+import { type IBlipColor, type IBlipSprite } from "../../../../shared";
 
 export interface IRageBlipOptions extends IRageWorldObjectOptions<EntityMp> {}
 

--- a/src/server/entities/ragemp/blip/RageBlipsManager.ts
+++ b/src/server/entities/ragemp/blip/RageBlipsManager.ts
@@ -1,4 +1,4 @@
-import { IBlipCreateOptions, IBlipsManager } from "../../common";
+import { type IBlipCreateOptions, type IBlipsManager } from "../../common";
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 import { RageBlip } from "./RageBlip";
 

--- a/src/server/entities/ragemp/colshape/RageCircleColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageCircleColshape.ts
@@ -1,5 +1,5 @@
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
-import { ICircleColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICircleColshape } from "../../common";
 
 export interface IRageCircleColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/server/entities/ragemp/colshape/RageColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageColshape.ts
@@ -1,4 +1,4 @@
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
 
 export interface IRageColshapeOptions extends IRageWorldObjectOptions<ColshapeMp> {}
 

--- a/src/server/entities/ragemp/colshape/RageColshapesManager.ts
+++ b/src/server/entities/ragemp/colshape/RageColshapesManager.ts
@@ -1,12 +1,12 @@
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
-import { RageColshape } from "./RageColshape";
+import { type RageColshape } from "./RageColshape";
 import {
-  ICircleColshapeCreateOptions,
-  IColshapesManager,
-  ICuboidColshapeCreateOptions,
-  ICylinderColshapeCreateOptions,
-  IRectangleColshapeCreateOptions,
-  ISphereColshapeCreateOptions,
+  type ICircleColshapeCreateOptions,
+  type IColshapesManager,
+  type ICuboidColshapeCreateOptions,
+  type ICylinderColshapeCreateOptions,
+  type IRectangleColshapeCreateOptions,
+  type ISphereColshapeCreateOptions,
 } from "../../common";
 import { RageCircleColshape } from "./RageCircleColshape";
 import { RageCuboidColshape } from "./RageCuboidColshape";

--- a/src/server/entities/ragemp/colshape/RageCuboidColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageCuboidColshape.ts
@@ -1,5 +1,5 @@
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
-import { ICuboidColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICuboidColshape } from "../../common";
 
 export interface IRageCuboidColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/server/entities/ragemp/colshape/RageCylinderColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageCylinderColshape.ts
@@ -1,5 +1,5 @@
-import { ICylinderColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ICylinderColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageCylinderColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/server/entities/ragemp/colshape/RageRectangleColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageRectangleColshape.ts
@@ -1,5 +1,5 @@
-import { IRectangleColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type IRectangleColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageRectangleColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/server/entities/ragemp/colshape/RageSphereColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageSphereColshape.ts
@@ -1,5 +1,5 @@
-import { ISphereColshape } from "../../common";
-import { IRageColshapeOptions, RageColshape } from "./RageColshape";
+import { type ISphereColshape } from "../../common";
+import { type IRageColshapeOptions, RageColshape } from "./RageColshape";
 
 export interface IRageSphereColshapeOptions extends IRageColshapeOptions {}
 

--- a/src/server/entities/ragemp/entity/RageEntitiesManager.ts
+++ b/src/server/entities/ragemp/entity/RageEntitiesManager.ts
@@ -1,6 +1,6 @@
-import { IEntitiesManager } from "../../common/entity/IEntitiesManager";
-import { RageEntity } from "./RageEntity";
-import { IRageWorldObjectsManagerOptions, RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
+import { type IEntitiesManager } from "../../common/entity/IEntitiesManager";
+import { type RageEntity } from "./RageEntity";
+import { type IRageWorldObjectsManagerOptions, RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 
 export interface IRageEntitiesManagerOptions extends IRageWorldObjectsManagerOptions {}
 

--- a/src/server/entities/ragemp/entity/RageEntity.ts
+++ b/src/server/entities/ragemp/entity/RageEntity.ts
@@ -1,5 +1,5 @@
-import { IEntity } from "../../common/entity/IEntity";
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IEntity } from "../../common/entity/IEntity";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
 import { Vector3D } from "../../../../shared/common/utils";
 
 export interface IRageEntityOptions<T extends EntityMp> extends IRageWorldObjectOptions<T> {}

--- a/src/server/entities/ragemp/marker/RageMarker.ts
+++ b/src/server/entities/ragemp/marker/RageMarker.ts
@@ -1,7 +1,7 @@
-import { IMarker } from "../../common";
-import { IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
-import { IRGBA, IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
-import { IMarkerType } from "../../../../shared";
+import { type IMarker } from "../../common";
+import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
+import { type IRGBA, type IVector3D, RGBA, Vector3D } from "../../../../shared/common/utils";
+import { type IMarkerType } from "../../../../shared";
 
 export interface IRageMarkerOptions extends IRageWorldObjectOptions<MarkerMp> {}
 

--- a/src/server/entities/ragemp/marker/RageMarkersManager.ts
+++ b/src/server/entities/ragemp/marker/RageMarkersManager.ts
@@ -1,4 +1,4 @@
-import { IMarkerCreateOptions, IMarkersManager } from "../../common";
+import { type IMarkerCreateOptions, type IMarkersManager } from "../../common";
 import { RageWorldObjectsManager } from "../worldObject/RageWorldObjectsManager";
 import { RageMarker } from "./RageMarker";
 

--- a/src/server/entities/ragemp/object/RageObject.ts
+++ b/src/server/entities/ragemp/object/RageObject.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IObject } from "../../common/object/IObject";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IObject } from "../../common/object/IObject";
 
 export interface IRageObjectOptions extends IRageEntityOptions<ObjectMp> {}
 

--- a/src/server/entities/ragemp/object/RageObjectsManager.ts
+++ b/src/server/entities/ragemp/object/RageObjectsManager.ts
@@ -1,4 +1,4 @@
-import { IObjectCreateOptions, IObjectsManager } from "../../common/object/IObjectsManager";
+import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RageObject } from "./RageObject";
 

--- a/src/server/entities/ragemp/ped/RagePed.ts
+++ b/src/server/entities/ragemp/ped/RagePed.ts
@@ -1,5 +1,5 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IPed } from "../../common";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IPed } from "../../common";
 
 export interface IRagePedOptions extends IRageEntityOptions<PedMp> {}
 

--- a/src/server/entities/ragemp/ped/RagePedsManager.ts
+++ b/src/server/entities/ragemp/ped/RagePedsManager.ts
@@ -1,4 +1,4 @@
-import { IPedCreateOptions, IPedsManager } from "../../common";
+import { type IPedCreateOptions, type IPedsManager } from "../../common";
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RagePed } from "./RagePed";
 

--- a/src/server/entities/ragemp/player/RagePlayer.ts
+++ b/src/server/entities/ragemp/player/RagePlayer.ts
@@ -1,10 +1,10 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { ICustomization, IPlayer } from "../../common/player/IPlayer";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type ICustomization, type IPlayer } from "../../common/player/IPlayer";
 import { RockMod } from "../../../RockMod";
-import { RageVehicle } from "../vehicle/RageVehicle";
+import { type RageVehicle } from "../vehicle/RageVehicle";
 import { MathClamp } from "../../../../shared/common/utils/math/Math";
-import { IServerToClientEvents, Vector3D } from "../../../../shared";
-import { IClientRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IServerToClientEvents, type Vector3D } from "../../../../shared";
+import { type IClientRPCList } from "../../../../shared/net/common/rpc/types";
 
 interface IRagePlayerOptions extends IRageEntityOptions<PlayerMp> {}
 

--- a/src/server/entities/ragemp/player/RagePlayersManager.ts
+++ b/src/server/entities/ragemp/player/RagePlayersManager.ts
@@ -1,7 +1,7 @@
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RagePlayer } from "./RagePlayer";
-import { IPlayersManager } from "../../common/player/IPlayersManager";
-import { RageNetManager } from "../../../net/ragemp/RageNetManager";
+import { type IPlayersManager } from "../../common/player/IPlayersManager";
+import { type RageNetManager } from "../../../net/ragemp/RageNetManager";
 import { ServerInternalEventName } from "../../../net/common/events/types";
 
 export class RagePlayersManager extends RageEntitiesManager<RagePlayer> implements IPlayersManager {

--- a/src/server/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/server/entities/ragemp/vehicle/RageVehicle.ts
@@ -1,7 +1,7 @@
-import { IRageEntityOptions, RageEntity } from "../entity/RageEntity";
-import { IVehicle } from "../../common/vehicle/IVehicle";
+import { type IRageEntityOptions, RageEntity } from "../entity/RageEntity";
+import { type IVehicle } from "../../common/vehicle/IVehicle";
 import { RGBA } from "../../../../shared/common/utils";
-import { RagePlayer } from "../player/RagePlayer";
+import { type RagePlayer } from "../player/RagePlayer";
 import { RockMod } from "../../../RockMod";
 
 export interface IRageVehicleOptions extends IRageEntityOptions<VehicleMp> {}

--- a/src/server/entities/ragemp/vehicle/RageVehiclesManager.ts
+++ b/src/server/entities/ragemp/vehicle/RageVehiclesManager.ts
@@ -1,6 +1,6 @@
 import { RageEntitiesManager } from "../entity/RageEntitiesManager";
 import { RageVehicle } from "./RageVehicle";
-import { IVehicleCreateOptions, IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
+import { type IVehicleCreateOptions, type IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
 
 export interface IRageVehicleCreateOptions extends IVehicleCreateOptions {}
 

--- a/src/server/entities/ragemp/worldObject/RageWorldObject.ts
+++ b/src/server/entities/ragemp/worldObject/RageWorldObject.ts
@@ -1,5 +1,5 @@
-import { IWorldObject } from "../../common/worldObject/IWorldObject";
-import { IRageBaseObjectOptions, RageBaseObject } from "../baseObject/RageBaseObject";
+import { type IWorldObject } from "../../common/worldObject/IWorldObject";
+import { type IRageBaseObjectOptions, RageBaseObject } from "../baseObject/RageBaseObject";
 import { Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export interface IRageWorldObjectOptions<T extends EntityMp> extends IRageBaseObjectOptions<T> {}

--- a/src/server/entities/ragemp/worldObject/RageWorldObjectsIterator.ts
+++ b/src/server/entities/ragemp/worldObject/RageWorldObjectsIterator.ts
@@ -1,7 +1,7 @@
-import { RageWorldObject } from "./RageWorldObject";
+import { type RageWorldObject } from "./RageWorldObject";
 import { RageBaseObjectsIterator } from "../baseObject/RageBaseObjectsIterator";
-import { IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
-import { Vector2D, Vector3D } from "../../../../shared/common/utils/math/Vectors";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { type Vector2D, type Vector3D } from "../../../../shared/common/utils/math/Vectors";
 
 export class RageWorldObjectsIterator<T extends RageWorldObject<EntityMp>>
   extends RageBaseObjectsIterator<T>

--- a/src/server/entities/ragemp/worldObject/RageWorldObjectsManager.ts
+++ b/src/server/entities/ragemp/worldObject/RageWorldObjectsManager.ts
@@ -1,6 +1,6 @@
-import { IWorldObjectsManager } from "../../common";
-import { IRageBaseObjectsManagerOptions, RageBaseObjectsManager } from "../baseObject/RageBaseObjectsManager";
-import { RageWorldObject } from "./RageWorldObject";
+import { type IWorldObjectsManager } from "../../common";
+import { type IRageBaseObjectsManagerOptions, RageBaseObjectsManager } from "../baseObject/RageBaseObjectsManager";
+import { type RageWorldObject } from "./RageWorldObject";
 import { RageWorldObjectsIterator } from "./RageWorldObjectsIterator";
 
 export interface IRageWorldObjectsManagerOptions extends IRageBaseObjectsManagerOptions {}

--- a/src/server/factories/altv/AltVManagersFactory.ts
+++ b/src/server/factories/altv/AltVManagersFactory.ts
@@ -1,4 +1,4 @@
-import { IManagersFactory } from "../common/IManagersFactory";
+import { type IManagersFactory } from "../common/IManagersFactory";
 import { AltVNetManager } from "../../net/altv/AltVNetManager";
 import { AltVBlipsManager } from "../../entities/altv/blip/AltVBlipsManager";
 import { AltVColshapesManager } from "../../entities/altv/colshape/AltVColshapesManager";

--- a/src/server/factories/common/IManagersFactory.ts
+++ b/src/server/factories/common/IManagersFactory.ts
@@ -1,14 +1,14 @@
-import { INetManager } from "../../net/common/INetManager";
+import { type INetManager } from "../../net/common/INetManager";
 import {
-  IBlipsManager,
-  IColshapesManager,
-  IMarkersManager,
-  IObjectsManager,
-  IPedsManager,
-  IPlayersManager,
-  IVehiclesManager,
+  type IBlipsManager,
+  type IColshapesManager,
+  type IMarkersManager,
+  type IObjectsManager,
+  type IPedsManager,
+  type IPlayersManager,
+  type IVehiclesManager,
 } from "../../entities";
-import { IUtilsManager } from "../../utils";
+import { type IUtilsManager } from "../../utils";
 
 export interface IManagersFactory {
   createNetManager(): INetManager;

--- a/src/server/factories/mock/MockManagersFactory.ts
+++ b/src/server/factories/mock/MockManagersFactory.ts
@@ -1,7 +1,7 @@
-import { IManagersFactory } from "../common/IManagersFactory";
+import { type IManagersFactory } from "../common/IManagersFactory";
 import { MockNetManager } from "../../net/mock/MockNetManager";
 import { MockPlayersManager } from "../../entities/mock/player/MockPlayersManager";
-import { IUtilsManager } from "../../utils";
+import { type IUtilsManager } from "../../utils";
 import { MockBlipsManager } from "../../entities/mock/blip/MockBlipsManager";
 import { MockColshapesManager } from "../../entities/mock/colshape/MockColshapesManager";
 import { MockMarkersManager } from "../../entities/mock/marker/MockMarkersManager";

--- a/src/server/factories/ragemp/RageManagersFactory.ts
+++ b/src/server/factories/ragemp/RageManagersFactory.ts
@@ -1,4 +1,4 @@
-import { IManagersFactory } from "../common/IManagersFactory";
+import { type IManagersFactory } from "../common/IManagersFactory";
 import { RageNetManager } from "../../net/ragemp/RageNetManager";
 import { RageBlipsManager } from "../../entities/ragemp/blip/RageBlipsManager";
 import { RageColshapesManager } from "../../entities/ragemp/colshape/RageColshapesManager";

--- a/src/server/net/altv/AltVNetManager.ts
+++ b/src/server/net/altv/AltVNetManager.ts
@@ -1,4 +1,4 @@
-import { INetManager } from "../common/INetManager";
+import { type INetManager } from "../common/INetManager";
 import { AltVEventsManager } from "./events/AltVEventsManager";
 import { AltVRPCManager } from "./rpc/AltVRPCManager";
 

--- a/src/server/net/altv/events/AltVEventsManager.ts
+++ b/src/server/net/altv/events/AltVEventsManager.ts
@@ -1,8 +1,8 @@
-import { IEventsManager } from "../../common/events/IEventsManager";
-import { IServerInternalEvents } from "../../common/events/types";
+import { type IEventsManager } from "../../common/events/IEventsManager";
+import { type IServerInternalEvents } from "../../common/events/types";
 import Player = AltVServer.Player;
-import { IClientToServerEvents, IServerToClientEvents } from "../../../../shared";
-import { AltVPlayer } from "../../../entities/altv/player/AltVPlayer";
+import { type IClientToServerEvents, type IServerToClientEvents } from "../../../../shared";
+import { type AltVPlayer } from "../../../entities/altv/player/AltVPlayer";
 
 interface IAltVServerInternalEvents extends IServerInternalEvents, AltVServer.IServerEvent {}
 

--- a/src/server/net/altv/rpc/AltVRPCManager.ts
+++ b/src/server/net/altv/rpc/AltVRPCManager.ts
@@ -1,9 +1,9 @@
-import { IRPCManager } from "../../common/rpc/IRPCManager";
-import { AltVPlayer } from "../../../entities/altv/player/AltVPlayer";
+import { type IRPCManager } from "../../common/rpc/IRPCManager";
+import { type AltVPlayer } from "../../../entities/altv/player/AltVPlayer";
 import alt = AltVServer;
 import shared = AltVShared;
 import Player = AltVServer.Player;
-import { IClientRPCList, IServerRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IClientRPCList, type IServerRPCList } from "../../../../shared/net/common/rpc/types";
 
 export interface IAltVServerRPC extends shared.ICustomClientServerRpc, IServerRPCList {}
 

--- a/src/server/net/common/INetManager.ts
+++ b/src/server/net/common/INetManager.ts
@@ -1,5 +1,5 @@
-import { IEventsManager } from "./events/IEventsManager";
-import { IRPCManager } from "./rpc/IRPCManager";
+import { type IEventsManager } from "./events/IEventsManager";
+import { type IRPCManager } from "./rpc/IRPCManager";
 
 export interface INetManager {
   get events(): IEventsManager;

--- a/src/server/net/common/events/IEventsManager.ts
+++ b/src/server/net/common/events/IEventsManager.ts
@@ -1,6 +1,6 @@
-import { IClientToServerEvents, IServerToClientEvents } from "../../../../shared";
-import { IServerInternalEvents } from "./types";
-import { IPlayer } from "../../../entities";
+import { type IClientToServerEvents, type IServerToClientEvents } from "../../../../shared";
+import { type IServerInternalEvents } from "./types";
+import { type IPlayer } from "../../../entities";
 
 export interface IEventsManager {
   onInternal(events: Partial<IServerInternalEvents>): void;

--- a/src/server/net/common/events/types.ts
+++ b/src/server/net/common/events/types.ts
@@ -1,4 +1,4 @@
-import { IBaseObject, IPlayer } from "../../../entities";
+import { type IBaseObject, type IPlayer } from "../../../entities";
 
 export enum ServerInternalEventName {
   PlayerConnected = "rm::playerConnected",

--- a/src/server/net/common/rpc/IRPCManager.ts
+++ b/src/server/net/common/rpc/IRPCManager.ts
@@ -1,5 +1,5 @@
-import { IPlayer } from "../../../entities/common/player/IPlayer";
-import { IClientRPCList, IServerRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IPlayer } from "../../../entities/common/player/IPlayer";
+import { type IClientRPCList, type IServerRPCList } from "../../../../shared/net/common/rpc/types";
 
 export interface IRPCManager {
   register<K extends keyof IServerRPCList>(

--- a/src/server/net/mock/MockNetManager.ts
+++ b/src/server/net/mock/MockNetManager.ts
@@ -1,4 +1,4 @@
-import { INetManager } from "../common/INetManager";
+import { type INetManager } from "../common/INetManager";
 import { MockEventsManager } from "./events/MockEventsManager";
 import { MockRPCManager } from "./rpc/MockRPCManager";
 

--- a/src/server/net/mock/events/MockEventsManager.ts
+++ b/src/server/net/mock/events/MockEventsManager.ts
@@ -1,8 +1,8 @@
-import { IEventsManager } from "../../common/events/IEventsManager";
+import { type IEventsManager } from "../../common/events/IEventsManager";
 import { EventEmitter } from "events";
-import { IServerInternalEvents } from "../../common/events/types";
-import { IClientToServerEvents, IServerToClientEvents } from "../../../../shared";
-import { MockPlayer } from "../../../entities/mock/player/MockPlayer";
+import { type IServerInternalEvents } from "../../common/events/types";
+import { type IClientToServerEvents, type IServerToClientEvents } from "../../../../shared";
+import { type MockPlayer } from "../../../entities/mock/player/MockPlayer";
 
 export class MockEventsManager implements IEventsManager {
   private readonly _eventEmitter = new EventEmitter();

--- a/src/server/net/mock/rpc/MockRPCManager.ts
+++ b/src/server/net/mock/rpc/MockRPCManager.ts
@@ -1,7 +1,7 @@
-import { IRPCManager } from "../../common/rpc/IRPCManager";
-import { IPlayer } from "../../../entities/common/player/IPlayer";
-import { MockPlayer } from "../../../entities/mock/player/MockPlayer";
-import { IClientRPCList, IServerRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IRPCManager } from "../../common/rpc/IRPCManager";
+import { type IPlayer } from "../../../entities/common/player/IPlayer";
+import { type MockPlayer } from "../../../entities/mock/player/MockPlayer";
+import { type IClientRPCList, type IServerRPCList } from "../../../../shared/net/common/rpc/types";
 
 export interface IMockServerRPC extends IServerRPCList {}
 

--- a/src/server/net/ragemp/RageNetManager.ts
+++ b/src/server/net/ragemp/RageNetManager.ts
@@ -1,4 +1,4 @@
-import { INetManager } from "../common/INetManager";
+import { type INetManager } from "../common/INetManager";
 import { RageEventsManager } from "./events/RageEventsManager";
 import { RageRPCManager } from "./rpc/RageRPCManager";
 

--- a/src/server/net/ragemp/events/RageEventsManager.ts
+++ b/src/server/net/ragemp/events/RageEventsManager.ts
@@ -1,7 +1,7 @@
-import { IEventsManager } from "../../common/events/IEventsManager";
-import { IServerInternalEvents } from "../../common/events/types";
-import { IClientToServerEvents, IServerToClientEvents } from "../../../../shared";
-import { RagePlayer } from "../../../entities/ragemp/player/RagePlayer";
+import { type IEventsManager } from "../../common/events/IEventsManager";
+import { type IServerInternalEvents } from "../../common/events/types";
+import { type IClientToServerEvents, type IServerToClientEvents } from "../../../../shared";
+import { type RagePlayer } from "../../../entities/ragemp/player/RagePlayer";
 
 interface IRageServerInternalEvents extends IServerInternalEvents, IServerEvents {}
 

--- a/src/server/net/ragemp/rpc/RageRPCManager.ts
+++ b/src/server/net/ragemp/rpc/RageRPCManager.ts
@@ -1,6 +1,6 @@
-import { IRPCManager } from "../../common/rpc/IRPCManager";
-import { RagePlayer } from "../../../entities/ragemp/player/RagePlayer";
-import { IClientRPCList, IServerRPCList } from "../../../../shared/net/common/rpc/types";
+import { type IRPCManager } from "../../common/rpc/IRPCManager";
+import { type RagePlayer } from "../../../entities/ragemp/player/RagePlayer";
+import { type IClientRPCList, type IServerRPCList } from "../../../../shared/net/common/rpc/types";
 
 export class RageRPCManager implements IRPCManager {
   public register<K extends keyof IServerRPCList>(

--- a/src/server/testing.ts
+++ b/src/server/testing.ts
@@ -1,6 +1,6 @@
-import { MockPlayer } from "entities/mock/player/MockPlayer";
+import { type MockPlayer } from "entities/mock/player/MockPlayer";
 import { RockMod } from "./RockMod";
-import { IMockPlayerConnectOptions, MockPlayersManager } from "./entities/mock/player/MockPlayersManager";
+import { IMockPlayerConnectOptions, type MockPlayersManager } from "./entities/mock/player/MockPlayersManager";
 
 export class RockModTesting {
   public static simulatePlayerConnect(options?: IMockPlayerConnectOptions): MockPlayer {

--- a/src/server/utils/altv/AltVUtilsManager.ts
+++ b/src/server/utils/altv/AltVUtilsManager.ts
@@ -1,4 +1,4 @@
-import { IUtilsManager } from "../common";
+import { type IUtilsManager } from "../common";
 
 export class AltVUtilsManager implements IUtilsManager {
   public hash(value: string): number {

--- a/src/server/utils/mock/MockUtilsManager.ts
+++ b/src/server/utils/mock/MockUtilsManager.ts
@@ -1,4 +1,4 @@
-import { IUtilsManager } from "../common";
+import { type IUtilsManager } from "../common";
 
 export class MockUtilsManager implements IUtilsManager {
   public hash(value: string): number {

--- a/src/server/utils/ragemp/RageUtilsManager.ts
+++ b/src/server/utils/ragemp/RageUtilsManager.ts
@@ -1,4 +1,4 @@
-import { IUtilsManager } from "../common";
+import { type IUtilsManager } from "../common";
 
 export class RageUtilsManager implements IUtilsManager {
   public hash(value: string): number {

--- a/src/shared/.eslintrc.json
+++ b/src/shared/.eslintrc.json
@@ -46,7 +46,14 @@
       }
     ],
     "@typescript-eslint/explicit-function-return-type": ["error"],
-    "@typescript-eslint/explicit-member-accessibility": ["error"]
+    "@typescript-eslint/explicit-member-accessibility": ["error"],
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        "prefer": "type-imports",
+        "fixStyle": "inline-type-imports"
+      }
+    ]
   },
   "settings": {
     "import/resolver": {


### PR DESCRIPTION
# 🚀 Rock-Mod v0.9.1

## 🛠️ Bug Fixes and Improvements

### 🐛 Entity System Fixes
- Fixed RAGE:MP entity handling by adding `ped` to unsupported entity types due to `entityDestroyed` event bug
- Enhanced entity type safety for better error prevention

### 🔧 Code Quality Improvements
- ♻️ Refactored TypeScript imports across the codebase to use explicit type imports
- 📦 Updated import statements to follow TypeScript best practices
- 🎯 Improved type safety and code organization

### 🔍 Technical Details
- Added explicit type imports using the `type` keyword for better type-only imports
- Enhanced type declarations for better TypeScript inference
- Improved code maintainability through consistent import patterns