### PR TITLE
Release 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/altv/colshape/AltVColshapesManager.ts
+++ b/src/server/entities/altv/colshape/AltVColshapesManager.ts
@@ -13,11 +13,15 @@ import { AltVCuboidColshape } from "./AltVCuboidColshape";
 import { AltVCylinderColshape } from "./AltVCylinderColshape";
 import { AltVRectangleColshape } from "./AltVRectangleColshape";
 import { AltVSphereColshape } from "./AltVSphereColshape";
+import { RockMod } from "../../../RockMod";
+import { ServerInternalEventName } from "../../../net/common/events/types";
+import { type AltVPlayer } from "../player/AltVPlayer";
 import ColshapeCircle = AltVServer.ColshapeCircle;
 import ColshapeCuboid = AltVServer.ColshapeCuboid;
 import ColshapeCylinder = AltVServer.ColshapeCylinder;
 import ColshapeRectangle = AltVServer.ColshapeRectangle;
 import ColshapeSphere = AltVServer.ColshapeSphere;
+import BaseObjectType = AltVShared.BaseObjectType;
 
 export interface IAltVCircleColshapeCreateOptions extends ICircleColshapeCreateOptions {}
 
@@ -30,9 +34,32 @@ export interface IAltVRectangleColshapeCreateOptions extends IRectangleColshapeC
 export interface IAltVSphereColshapeCreateOptions extends ISphereColshapeCreateOptions {}
 
 export class AltVColshapesManager extends AltVWorldObjectsManager<AltVColshape> implements IColshapesManager {
+  private readonly _colshapesParticipants = new Map<AltVColshape, Set<AltVPlayer>>();
+
   public constructor() {
     super({
       baseObjectsType: "colshape",
+    });
+
+    AltVServer.on("entityEnterColshape", (mpColshape, mpEntity) => {
+      if (mpEntity.type === BaseObjectType.Player) {
+        const player = RockMod.instance.players.getByID(mpEntity.id) as AltVPlayer;
+        const colshape = this.getByID(mpColshape.id);
+        const participants = this.getParticipants(colshape);
+
+        participants.add(player);
+        RockMod.instance.net.events.emitInternal(ServerInternalEventName.PlayerEnteredColshape, player, colshape);
+      }
+    });
+    AltVServer.on("entityLeaveColshape", (mpColshape, mpEntity) => {
+      if (mpEntity.type === BaseObjectType.Player) {
+        const player = RockMod.instance.players.getByID(mpEntity.id) as AltVPlayer;
+        const colshape = this.getByID(mpColshape.id);
+        const participants = this.getParticipants(colshape);
+
+        participants.delete(player);
+        RockMod.instance.net.events.emitInternal(ServerInternalEventName.PlayerLeftColshape, player, colshape);
+      }
     });
   }
 
@@ -99,5 +126,14 @@ export class AltVColshapesManager extends AltVWorldObjectsManager<AltVColshape> 
     this.registerBaseObject(colshape);
 
     return colshape;
+  }
+
+  public getParticipants(colshape: AltVColshape): Set<AltVPlayer> {
+    let participants = this._colshapesParticipants.get(colshape);
+    if (!participants) {
+      participants = new Set();
+      this._colshapesParticipants.set(colshape, participants);
+    }
+    return participants;
   }
 }

--- a/src/server/entities/common/colshape/IColshapesManager.ts
+++ b/src/server/entities/common/colshape/IColshapesManager.ts
@@ -6,6 +6,7 @@ import { type ICuboidColshape } from "./ICuboidColshape";
 import { type ICylinderColshape } from "./ICylinderColshape";
 import { type IRectangleColshape } from "./IRectangleColshape";
 import { type ISphereColshape } from "./ISphereColshape";
+import { type IPlayer } from "../player";
 
 export interface ICircleColshapeCreateOptions extends Omit<IWorldObjectCreateOptions, "position"> {
   position: IVector2D;
@@ -38,4 +39,5 @@ export interface IColshapesManager extends IWorldObjectsManager<IColshape> {
   createCylinder(options: ICylinderColshapeCreateOptions): ICylinderColshape;
   createRectangle(options: IRectangleColshapeCreateOptions): IRectangleColshape;
   createSphere(options: ISphereColshapeCreateOptions): ISphereColshape;
+  getParticipants(colshape: IColshape): Set<IPlayer>;
 }

--- a/src/server/entities/mock/colshape/MockColshapesManager.ts
+++ b/src/server/entities/mock/colshape/MockColshapesManager.ts
@@ -15,6 +15,7 @@ import { MockRectangleColshape } from "./MockRectangleColshape";
 import { MockSphereColshape } from "./MockSphereColshape";
 import { type MockColshape } from "./MockColshape";
 import { BaseObjectType } from "../../../../shared";
+import { type MockPlayer } from "../player/MockPlayer";
 
 export interface IMockCircleColshapeCreateOptions extends ICircleColshapeCreateOptions {}
 export interface IMockCuboidColshapeCreateOptions extends ICuboidColshapeCreateOptions {}
@@ -115,5 +116,9 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
 
     this.registerBaseObject(colshape);
     return colshape;
+  }
+
+  public getParticipants(): Set<MockPlayer> {
+    return new Set();
   }
 }

--- a/src/server/entities/ragemp/colshape/RageColshapesManager.ts
+++ b/src/server/entities/ragemp/colshape/RageColshapesManager.ts
@@ -13,6 +13,9 @@ import { RageCuboidColshape } from "./RageCuboidColshape";
 import { RageCylinderColshape } from "./RageCylinderColshape";
 import { RageRectangleColshape } from "./RageRectangleColshape";
 import { RageSphereColshape } from "./RageSphereColshape";
+import { RockMod } from "../../../RockMod";
+import { ServerInternalEventName } from "../../../net/common/events/types";
+import { type RagePlayer } from "../player/RagePlayer";
 
 export interface IRageCircleColshapeCreateOptions extends ICircleColshapeCreateOptions {}
 
@@ -25,9 +28,28 @@ export interface IRageRectangleColshapeCreateOptions extends IRectangleColshapeC
 export interface IRageSphereColshapeCreateOptions extends ISphereColshapeCreateOptions {}
 
 export class RageColshapesManager extends RageWorldObjectsManager<RageColshape> implements IColshapesManager {
+  private readonly _colshapesParticipants = new Map<RageColshape, Set<RagePlayer>>();
+
   public constructor() {
     super({
       baseObjectsType: "colshape",
+    });
+
+    mp.events.add("playerEnterColshape", (mpPlayer, mpColshape) => {
+      const player = RockMod.instance.players.getByID(mpPlayer.id) as RagePlayer;
+      const colshape = this.getByID(mpColshape.id);
+      const participants = this.getParticipants(colshape);
+
+      participants.add(player);
+      RockMod.instance.net.events.emitInternal(ServerInternalEventName.PlayerEnteredColshape, player, colshape);
+    });
+    mp.events.add("playerExitColshape", (mpPlayer, mpColshape) => {
+      const player = RockMod.instance.players.getByID(mpPlayer.id) as RagePlayer;
+      const colshape = this.getByID(mpColshape.id);
+      const participants = this.getParticipants(colshape);
+
+      participants.delete(player);
+      RockMod.instance.net.events.emitInternal(ServerInternalEventName.PlayerLeftColshape, player, colshape);
     });
   }
 
@@ -94,5 +116,14 @@ export class RageColshapesManager extends RageWorldObjectsManager<RageColshape> 
     this.registerBaseObject(colshape);
 
     return colshape;
+  }
+
+  public getParticipants(colshape: RageColshape): Set<RagePlayer> {
+    let participants = this._colshapesParticipants.get(colshape);
+    if (!participants) {
+      participants = new Set();
+      this._colshapesParticipants.set(colshape, participants);
+    }
+    return participants;
   }
 }

--- a/src/server/net/common/events/types.ts
+++ b/src/server/net/common/events/types.ts
@@ -1,8 +1,10 @@
-import { type IBaseObject, type IPlayer } from "../../../entities";
+import { type IBaseObject, type IColshape, type IPlayer } from "../../../entities";
 
 export enum ServerInternalEventName {
   PlayerConnected = "rm::playerConnected",
   PlayerDisconnected = "rm::playerDisconnected",
+  PlayerEnteredColshape = "rm::playerEnteredColshape",
+  PlayerLeftColshape = "rm::playerLeftColshape",
   EntityCreated = "rm::entityCreated",
   EntityDestroyed = "rm::entityDestroyed",
 }
@@ -10,6 +12,8 @@ export enum ServerInternalEventName {
 export interface IServerInternalEvents {
   [ServerInternalEventName.PlayerConnected]: (player: IPlayer) => void;
   [ServerInternalEventName.PlayerDisconnected]: (player: IPlayer) => void;
+  [ServerInternalEventName.PlayerEnteredColshape]: (player: IPlayer, colshape: IColshape) => void;
+  [ServerInternalEventName.PlayerLeftColshape]: (player: IPlayer, colshape: IColshape) => void;
   [ServerInternalEventName.EntityCreated]: (object: IBaseObject) => void;
   [ServerInternalEventName.EntityDestroyed]: (object: IBaseObject) => void;
 }


### PR DESCRIPTION
# RockMod 0.10.0

## Major Features
- Added colshape participant tracking system
  - New events for player entering/leaving colshapes
  - Participant tracking for both AltV and RAGE:MP platforms
  - Added `getParticipants()` method to colshape managers

## Internal Events
Added new internal events for colshape interactions:
- `PlayerEnteredColshape`
- `PlayerLeftColshape`

## Improvements
- Enhanced type safety for events and RPC systems
- Improved entity management system
- Updated TypeScript imports to use explicit type imports
- Optimized build configuration and scripts

## Bug Fixes
- Fixed entity destroyed event handling for peds in RAGE:MP
- Fixed entity destroyed event handling for vehicles in RAGE:MP

## Breaking Changes
- None

## Platform Support
- Full support for alt:V
- Full support for RAGE:MP (with noted entity event limitations)