### PR TITLE
Release 0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/altv/entity/AltVEntity.ts
+++ b/src/server/entities/altv/entity/AltVEntity.ts
@@ -28,4 +28,12 @@ export abstract class AltVEntity<T extends Entity> extends AltVWorldObject<T> im
   public setRotation(value: Vector3D): void {
     this.mpEntity.rot = new Vector3(value);
   }
+
+  public getNetData(name: string): unknown {
+    return this.mpEntity.getSyncedMeta(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this.mpEntity.setSyncedMeta({ name, value });
+  }
 }

--- a/src/server/entities/common/entity/IEntity.ts
+++ b/src/server/entities/common/entity/IEntity.ts
@@ -8,4 +8,6 @@ export interface IEntity extends IWorldObject {
   get rotation(): IVector3D;
   setModel(value: string): void;
   setRotation(value: IVector3D): void;
+  getNetData(name: string): unknown;
+  setNetData(name: string, value: unknown): void;
 }

--- a/src/server/entities/mock/entity/MockEntity.ts
+++ b/src/server/entities/mock/entity/MockEntity.ts
@@ -13,6 +13,8 @@ export abstract class MockEntity extends MockWorldObject implements IEntity {
 
   private _rotation: IVector3D;
 
+  private _netData: Map<string, unknown>;
+
   public get model(): number {
     return this._model;
   }
@@ -27,6 +29,7 @@ export abstract class MockEntity extends MockWorldObject implements IEntity {
 
     this._model = options.model;
     this._rotation = options.rotation;
+    this._netData = new Map();
   }
 
   public setModel(value: string): void {
@@ -35,5 +38,13 @@ export abstract class MockEntity extends MockWorldObject implements IEntity {
 
   public setRotation(value: Vector3D): void {
     this._rotation = value;
+  }
+
+  public getNetData(name: string): unknown {
+    return this._netData.get(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this._netData.set(name, value);
   }
 }

--- a/src/server/entities/ragemp/entity/RageEntity.ts
+++ b/src/server/entities/ragemp/entity/RageEntity.ts
@@ -25,4 +25,12 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
   public setRotation(value: Vector3D): void {
     this.mpEntity.rotation = new mp.Vector3(value);
   }
+
+  public getNetData(name: string): unknown {
+    return this.mpEntity.getVariable(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this.mpEntity.setVariable(name, value);
+  }
 }


### PR DESCRIPTION
## Description
This PR implements network data synchronization capabilities across all entity implementations.

### Changes
- Added `getNetData` and `setNetData` methods to the `IEntity` interface
- Implemented these methods in:
  - RageMP entities using `getVariable`/`setVariable`
  - AltV entities using `getSyncedMeta`/`setSyncedMeta`
  - Mock entities using an internal Map for testing

These methods provide a consistent way to access and modify network-synchronized data across our different platform implementations, making it easier to share state between server and client.
