### PR TITLE
Release 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/ragemp/baseObject/RageBaseObject.ts
+++ b/src/server/entities/ragemp/baseObject/RageBaseObject.ts
@@ -2,7 +2,14 @@ import { type IBaseObject, type IBaseObjectOptions } from "../../common/baseObje
 import { type BaseObjectType } from "../../../../shared";
 
 // RAGEMP BUG: event 'entityDestroyed' is not callable
-const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set(["blip", "colshape", "object", "ped", "vehicle"]);
+const unsupportedRageEntityTypes: Set<`${BaseObjectType}`> = new Set([
+  "blip",
+  "colshape",
+  "marker",
+  "object",
+  "ped",
+  "vehicle",
+]);
 
 export interface IRageBaseObjectOptions<T extends EntityMp> extends IBaseObjectOptions {
   mpEntity: T;


### PR DESCRIPTION
## Fix: RAGEMP marker entityDestroyed event bug

Added `marker` to unsupported RAGEMP entity types due to `entityDestroyed` event not being callable, preventing potential crashes when marker entities are destroyed.