### PR TITLE
Release 0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/altv/vehicle/AltVVehicle.ts
+++ b/src/server/entities/altv/vehicle/AltVVehicle.ts
@@ -115,6 +115,40 @@ export class AltVVehicle extends AltVEntity<Vehicle> implements IVehicle {
     this.mpEntity.customSecondaryColor = new AltVShared.RGBA(r, g, b, a);
   }
 
+  public setMod(modType: number, modIndex: number): void {
+    this.mpEntity.setMod(modType, modIndex);
+  }
+
+  public getMod(modType: number): number {
+    return this.mpEntity.getMod(modType);
+  }
+
+  public setNeonEnabled(enabled: boolean): void {
+    this.mpEntity.neon = {
+      ...this.mpEntity.neon,
+      left: enabled,
+      right: enabled,
+      front: enabled,
+      back: enabled,
+    };
+  }
+
+  public setNeonColor(r: number, g: number, b: number): void {
+    this.mpEntity.neonColor = new AltVShared.RGBA(r, g, b);
+  }
+
+  public setWindowTint(tintType: number): void {
+    this.mpEntity.windowTint = tintType;
+  }
+
+  public setWheelType(wheelType: number): void {
+    this.mpEntity.setWheels(wheelType, 0);
+  }
+
+  public setPlateType(plateType: number): void {
+    this.mpEntity.numberPlateIndex = plateType;
+  }
+
   public explode(): void {
     this.mpEntity.engineHealth = 0;
     this.mpEntity.bodyHealth = 0;

--- a/src/server/entities/common/vehicle/IVehicle.ts
+++ b/src/server/entities/common/vehicle/IVehicle.ts
@@ -46,6 +46,13 @@ export interface IVehicle extends IEntity {
   setSecondaryColor(value: number): void;
   setCustomPrimaryColor(value: IRGBA): void;
   setCustomSecondaryColor(value: IRGBA): void;
+  setMod(modType: number, modIndex: number): void;
+  getMod(modType: number): number;
+  setNeonEnabled(enabled: boolean): void;
+  setNeonColor(r: number, g: number, b: number): void;
+  setWindowTint(tintType: number): void;
+  setWheelType(wheelType: number): void;
+  setPlateType(plateType: number): void;
   explode(): void;
   repair(): void;
 }

--- a/src/server/entities/mock/vehicle/MockVehicle.ts
+++ b/src/server/entities/mock/vehicle/MockVehicle.ts
@@ -32,6 +32,18 @@ export class MockVehicle extends MockEntity implements IVehicle {
 
   private _passengers: Set<MockPlayer>;
 
+  private _mods: Map<number, number>;
+
+  private _neonEnabled: boolean;
+
+  private _neonColor: { r: number; g: number; b: number };
+
+  private _windowTint: number;
+
+  private _wheelType: number;
+
+  private _plateType: number;
+
   public get bodyHealth(): number {
     return this._bodyHealth;
   }
@@ -76,6 +88,26 @@ export class MockVehicle extends MockEntity implements IVehicle {
     return new RGBA(r, g, b, a);
   }
 
+  public get neonEnabled(): boolean {
+    return this._neonEnabled;
+  }
+
+  public get neonColor(): { r: number; g: number; b: number } {
+    return this._neonColor;
+  }
+
+  public get windowTint(): number {
+    return this._windowTint;
+  }
+
+  public get wheelType(): number {
+    return this._wheelType;
+  }
+
+  public get plateType(): number {
+    return this._plateType;
+  }
+
   public get driver(): MockPlayer | null {
     for (const passenger of this._passengers.values()) {
       if (passenger.seat === 0) {
@@ -104,6 +136,12 @@ export class MockVehicle extends MockEntity implements IVehicle {
     this._customPrimaryColor = new RGBA(0, 0, 0);
     this._customSecondaryColor = new RGBA(0, 0, 0);
     this._passengers = new Set();
+    this._mods = new Map();
+    this._neonEnabled = false;
+    this._neonColor = { r: 0, g: 0, b: 0 };
+    this._windowTint = 0;
+    this._wheelType = 0;
+    this._plateType = 0;
   }
 
   public setBodyHealth(value: number): void {
@@ -140,6 +178,34 @@ export class MockVehicle extends MockEntity implements IVehicle {
 
   public setCustomSecondaryColor(value: RGBA): void {
     this._customSecondaryColor = value;
+  }
+
+  public setMod(modType: number, modIndex: number): void {
+    this._mods.set(modType, modIndex);
+  }
+
+  public getMod(modType: number): number {
+    return this._mods.get(modType) ?? -1;
+  }
+
+  public setNeonEnabled(enabled: boolean): void {
+    this._neonEnabled = enabled;
+  }
+
+  public setNeonColor(r: number, g: number, b: number): void {
+    this._neonColor = { r, g, b };
+  }
+
+  public setWindowTint(tintType: number): void {
+    this._windowTint = tintType;
+  }
+
+  public setWheelType(wheelType: number): void {
+    this._wheelType = wheelType;
+  }
+
+  public setPlateType(plateType: number): void {
+    this._plateType = plateType;
   }
 
   public explode(): void {

--- a/src/server/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/server/entities/ragemp/vehicle/RageVehicle.ts
@@ -125,6 +125,34 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
     );
   }
 
+  public setMod(modType: number, modIndex: number): void {
+    this.mpEntity.setMod(modType, modIndex);
+  }
+
+  public getMod(modType: number): number {
+    return this.mpEntity.getMod(modType);
+  }
+
+  public setNeonEnabled(enabled: boolean): void {
+    this.mpEntity.neonEnabled = enabled;
+  }
+
+  public setNeonColor(r: number, g: number, b: number): void {
+    this.mpEntity.setNeonColor(r, g, b);
+  }
+
+  public setWindowTint(tintType: number): void {
+    this.mpEntity.windowTint = tintType;
+  }
+
+  public setWheelType(wheelType: number): void {
+    this.mpEntity.wheelType = wheelType;
+  }
+
+  public setPlateType(plateType: number): void {
+    this.mpEntity.numberPlateType = plateType;
+  }
+
   public explode(): void {
     return this.mpEntity.explode();
   }


### PR DESCRIPTION
### Vehicle customization API

Vehicle entities now support a unified customization API across RageMP, AltV, and Mock:

- **Mods** — `setMod(modType, modIndex)` and `getMod(modType)` for vehicle mods (spoilers, bumpers, horns, etc.)
- **Neon** — `setNeonEnabled(enabled)` and `setNeonColor(r, g, b)` for neon lights and color
- **Window tint** — `setWindowTint(tintType)` for window tint level
- **Wheel type** — `setWheelType(wheelType)` for wheel style
- **Plate type** — `setPlateType(plateType)` for license plate style

All methods are available on the shared `IVehicle` interface and work consistently on all supported platforms.