### PR TITLE
Release 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/entities/common/entity/IEntity.ts
+++ b/src/client/entities/common/entity/IEntity.ts
@@ -1,3 +1,4 @@
+import { type IBaseObject } from "../baseObject";
 import { type IWorldObject, type IWorldObjectOptions } from "../worldObject/IWorldObject";
 import { type IVector3D } from "@shared/common/utils";
 
@@ -22,4 +23,20 @@ export interface IEntity extends IWorldObject {
   getBoneIndexByName(boneName: string): number;
   getWorldPositionOfBone(boneIndex: number): IVector3D;
   getVariable(name: string): unknown | null;
+
+  attachToEntity(
+    target: IBaseObject,
+    boneIndex: number,
+    offset: IVector3D,
+    rotation: IVector3D,
+    p9: boolean,
+    useSoftPinning: boolean,
+    collision: boolean,
+    isPed: boolean,
+    vertexIndex: number,
+    fixedRot: boolean,
+  ): void;
+  detach(useDetachVelocity: boolean, collision: boolean): void;
+  getSpeed(): number;
+  isPlayingAnim(dictionary: string, name: string, taskFlag: number): boolean;
 }

--- a/src/client/entities/common/object/IObject.ts
+++ b/src/client/entities/common/object/IObject.ts
@@ -19,5 +19,4 @@ export interface IObject extends IEntity {
     fixedRot: boolean,
   ): void;
   isAttachedTo(entity: number): boolean;
-  detach(applyVelocy: boolean, collision: boolean): void;
 }

--- a/src/client/entities/common/player/IPlayer.ts
+++ b/src/client/entities/common/player/IPlayer.ts
@@ -54,6 +54,7 @@ export interface IPlayer extends IEntity {
   taskSwapWeapon(): void;
   taskEnterVehicle(vehicleHandle: number, timeout: number, seat: number, speed: number, flag: number, p6: number): void;
   clearTasks(): void;
+  clearTasksImmediately(): void;
   taskPlayAnim(
     dictionary: string,
     name: string,
@@ -66,6 +67,7 @@ export interface IPlayer extends IEntity {
     lockY: boolean,
     lockZ: boolean,
   ): void;
+  stopAnim(dictionary: string, name: string, blendOutSpeed: number): void;
 
   setMovementClipset(clipset: string, speed: number): void;
   resetMovementClipset(blendDuration: number): void;

--- a/src/client/entities/common/player/IPlayersManager.ts
+++ b/src/client/entities/common/player/IPlayersManager.ts
@@ -4,6 +4,8 @@ import { type IPlayer } from "./IPlayer";
 export interface IPlayersManager extends IEntitiesManager<IPlayer> {
   getByName(name: string): IPlayer;
   findByName(name: string): IPlayer | null;
+  findByRemoteId(remoteId: number): IPlayer | null;
+  getByRemoteId(remoteId: number): IPlayer;
   findLocalPlayer(): IPlayer | null;
   getLocalPlayer(): IPlayer;
 }

--- a/src/client/entities/common/vehicle/IVehicle.ts
+++ b/src/client/entities/common/vehicle/IVehicle.ts
@@ -49,4 +49,11 @@ export interface IVehicle extends IEntity {
 
   setDoorOpen(doorIndex: number, loose: boolean, openInstantly: boolean): void;
   setDoorShut(doorIndex: number, instantly: boolean): void;
+
+  setHandling(field: string, value: number): void;
+  getHandling(field: string): number;
+  setEnginePowerMultiplier(value: number): void;
+  setEngineTorqueMultiplier(value: number): void;
+  modifyTopSpeed(value: number): void;
+  setCheatPowerIncrease(value: number): void;
 }

--- a/src/client/entities/ragemp/entity/RageEntity.ts
+++ b/src/client/entities/ragemp/entity/RageEntity.ts
@@ -1,3 +1,4 @@
+import { type IBaseObject } from "../../common/baseObject";
 import { type IEntity } from "../../common/entity/IEntity";
 import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
 import { type IVector3D, Vector3D } from "../../../../shared/common/utils";
@@ -83,5 +84,48 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
 
   public getVariable(name: string): unknown | null {
     return this.mpEntity.getVariable(name);
+  }
+
+  public attachToEntity(
+    target: IBaseObject,
+    boneIndex: number,
+    offset: IVector3D,
+    rotation: IVector3D,
+    p9: boolean,
+    useSoftPinning: boolean,
+    collision: boolean,
+    isPed: boolean,
+    vertexIndex: number,
+    fixedRot: boolean,
+  ): void {
+    mp.game.entity.attachToEntity(
+      this.handle,
+      target.handle,
+      boneIndex,
+      offset.x,
+      offset.y,
+      offset.z,
+      rotation.x,
+      rotation.y,
+      rotation.z,
+      p9,
+      useSoftPinning,
+      collision,
+      isPed,
+      vertexIndex,
+      fixedRot,
+    );
+  }
+
+  public detach(useDetachVelocity: boolean, collision: boolean): void {
+    mp.game.entity.detach(this.handle, useDetachVelocity, collision);
+  }
+
+  public getSpeed(): number {
+    return mp.game.entity.getSpeed(this.handle);
+  }
+
+  public isPlayingAnim(dictionary: string, name: string, taskFlag: number): boolean {
+    return mp.game.entity.isPlayingAnim(this.handle, dictionary, name, taskFlag);
   }
 }

--- a/src/client/entities/ragemp/object/RageObject.ts
+++ b/src/client/entities/ragemp/object/RageObject.ts
@@ -44,8 +44,4 @@ export class RageObject extends RageEntity<ObjectMp> implements IObject {
   public isAttachedTo(entity: number): boolean {
     return this.mpEntity.isAttachedTo(entity);
   }
-
-  public detach(applyVelocy: boolean, collision: boolean): void {
-    this.mpEntity.detach(applyVelocy, collision);
-  }
 }

--- a/src/client/entities/ragemp/player/RagePlayer.ts
+++ b/src/client/entities/ragemp/player/RagePlayer.ts
@@ -168,6 +168,14 @@ export class RagePlayer extends RageEntity<PlayerMp> implements IPlayer {
     this.mpEntity.clearTasks();
   }
 
+  public clearTasksImmediately(): void {
+    mp.game.task.clearPedTasksImmediately(this.handle);
+  }
+
+  public stopAnim(dictionary: string, name: string, blendOutSpeed: number): void {
+    mp.game.task.stopAnimTask(this.handle, dictionary, name, blendOutSpeed);
+  }
+
   public resetMovementClipset(blendDuration: number): void {
     this.mpEntity.resetMovementClipset(blendDuration);
   }

--- a/src/client/entities/ragemp/player/RagePlayersManager.ts
+++ b/src/client/entities/ragemp/player/RagePlayersManager.ts
@@ -29,6 +29,22 @@ export class RagePlayersManager extends RageEntitiesManager<RagePlayer> implemen
     return null;
   }
 
+  public findByRemoteId(remoteId: number): RagePlayer | null {
+    const mpPlayer = mp.players.atRemoteId(remoteId);
+    if (!mpPlayer) {
+      return null;
+    }
+    return this.findByID(mpPlayer.id);
+  }
+
+  public getByRemoteId(remoteId: number): RagePlayer {
+    const player = this.findByRemoteId(remoteId);
+    if (!player) {
+      throw new Error(`Player with remoteId ${remoteId} not found`);
+    }
+    return player;
+  }
+
   public findLocalPlayer(): RagePlayer | null {
     return this.findByID(mp.players.local.id);
   }

--- a/src/client/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehicle.ts
@@ -150,4 +150,28 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
   public setDoorShut(doorIndex: number, instantly: boolean): void {
     this.mpEntity.setDoorShut(doorIndex, instantly);
   }
+
+  public setHandling(field: string, value: number): void {
+    this.mpEntity.setHandling(field, value);
+  }
+
+  public getHandling(field: string): number {
+    return this.mpEntity.getHandling(field) as number;
+  }
+
+  public setEnginePowerMultiplier(value: number): void {
+    this.mpEntity.setEnginePowerMultiplier(value);
+  }
+
+  public setEngineTorqueMultiplier(value: number): void {
+    this.mpEntity.setEngineTorqueMultiplier(value);
+  }
+
+  public modifyTopSpeed(value: number): void {
+    mp.game.vehicle.modifyTopSpeed(this.handle, value);
+  }
+
+  public setCheatPowerIncrease(value: number): void {
+    mp.game.vehicle.setCheatPowerIncrease(this.handle, value);
+  }
 }

--- a/src/client/game/common/streaming/IStreamingManager.ts
+++ b/src/client/game/common/streaming/IStreamingManager.ts
@@ -1,7 +1,13 @@
+import { type IVector3D } from "@shared/common/utils";
+
 export interface IStreamingManager {
   requestAnimationDictionary(dictionary: string): void;
   hasAnimationDictionaryLoaded(dictionary: string): boolean;
+  removeAnimationDictionary(dictionary: string): void;
   isModelInCdimage(model: string): boolean;
   requestIpl(iplName: string): void;
   removeIpl(iplName: string): void;
+  setFocusArea(position: IVector3D, offset: IVector3D): void;
+  clearFocus(): void;
+  setFocusEntity(entityHandle: number): void;
 }

--- a/src/client/game/ragemp/streaming/RageStreamingManager.ts
+++ b/src/client/game/ragemp/streaming/RageStreamingManager.ts
@@ -1,4 +1,5 @@
 import { type IStreamingManager } from "@RockMod/client/game";
+import { type IVector3D } from "@shared/common/utils";
 
 export class RageStreamingManager implements IStreamingManager {
   public requestAnimationDictionary(dictionary: string): void {
@@ -7,6 +8,10 @@ export class RageStreamingManager implements IStreamingManager {
 
   public hasAnimationDictionaryLoaded(dictionary: string): boolean {
     return mp.game.streaming.hasAnimDictLoaded(dictionary);
+  }
+
+  public removeAnimationDictionary(dictionary: string): void {
+    mp.game.streaming.removeAnimDict(dictionary);
   }
 
   public isModelInCdimage(model: string): boolean {
@@ -20,5 +25,17 @@ export class RageStreamingManager implements IStreamingManager {
 
   public removeIpl(iplName: string): void {
     mp.game.streaming.removeIpl(iplName);
+  }
+
+  public setFocusArea(position: IVector3D, offset: IVector3D): void {
+    mp.game.streaming.setFocusArea(position.x, position.y, position.z, offset.x, offset.y, offset.z);
+  }
+
+  public clearFocus(): void {
+    mp.game.streaming.clearFocus();
+  }
+
+  public setFocusEntity(entityHandle: number): void {
+    mp.game.streaming.setFocusEntity(entityHandle);
   }
 }

--- a/src/server/entities/ragemp/player/RagePlayersManager.ts
+++ b/src/server/entities/ragemp/player/RagePlayersManager.ts
@@ -3,6 +3,8 @@ import { RagePlayer } from "./RagePlayer";
 import { type IPlayersManager } from "../../common/player/IPlayersManager";
 import { type RageNetManager } from "../../../net/ragemp/RageNetManager";
 import { ServerInternalEventName } from "../../../net/common/events/types";
+import { RockMod } from "../../../RockMod";
+import { type RageVehicle } from "../vehicle/RageVehicle";
 
 export class RagePlayersManager extends RageEntitiesManager<RagePlayer> implements IPlayersManager {
   public constructor(net: RageNetManager) {
@@ -63,11 +65,41 @@ export class RagePlayersManager extends RageEntitiesManager<RagePlayer> implemen
         this.registerBaseObject(player);
         net.events.emitInternal(ServerInternalEventName.PlayerConnected, player);
       },
-      playerQuit: (mpPlayer) => {
+      playerQuit: (mpPlayer, exitType, reason) => {
         const player = this.getByID(mpPlayer.id);
 
+        net.events.emitInternal(ServerInternalEventName.PlayerQuit, player, exitType, reason);
         this.unregisterBaseObject(player);
         net.events.emitInternal(ServerInternalEventName.PlayerDisconnected, player);
+      },
+      playerDeath: (mpPlayer, reason, killer) => {
+        const player = this.getByID(mpPlayer.id);
+        const killerPlayer = killer ? (RockMod.instance.players.findByID(killer.id) ?? null) : null;
+
+        net.events.emitInternal(ServerInternalEventName.PlayerDeath, player, reason, killerPlayer);
+      },
+      playerDamage: (mpPlayer, healthLoss, armourLoss) => {
+        const player = this.getByID(mpPlayer.id);
+
+        net.events.emitInternal(ServerInternalEventName.PlayerDamage, player, healthLoss, armourLoss);
+      },
+      playerEnterVehicle: (mpPlayer, mpVehicle, seat) => {
+        const player = this.getByID(mpPlayer.id);
+        const vehicle = RockMod.instance.vehicles.findByID(mpVehicle.id) as RageVehicle | null;
+        if (!vehicle) {
+          return;
+        }
+
+        net.events.emitInternal(ServerInternalEventName.PlayerEnterVehicle, player, vehicle, seat);
+      },
+      playerExitVehicle: (mpPlayer, mpVehicle) => {
+        const player = this.getByID(mpPlayer.id);
+        const vehicle = RockMod.instance.vehicles.findByID(mpVehicle.id) as RageVehicle | null;
+        if (!vehicle) {
+          return;
+        }
+
+        net.events.emitInternal(ServerInternalEventName.PlayerExitVehicle, player, vehicle);
       },
     });
   }

--- a/src/server/net/common/events/types.ts
+++ b/src/server/net/common/events/types.ts
@@ -1,8 +1,13 @@
-import { type IBaseObject, type IColshape, type IPlayer } from "../../../entities";
+import { type IBaseObject, type IColshape, type IPlayer, type IVehicle } from "../../../entities";
 
 export enum ServerInternalEventName {
   PlayerConnected = "rm::playerConnected",
   PlayerDisconnected = "rm::playerDisconnected",
+  PlayerQuit = "rm::playerQuit",
+  PlayerDeath = "rm::playerDeath",
+  PlayerDamage = "rm::playerDamage",
+  PlayerEnterVehicle = "rm::playerEnterVehicle",
+  PlayerExitVehicle = "rm::playerExitVehicle",
   PlayerEnteredColshape = "rm::playerEnteredColshape",
   PlayerLeftColshape = "rm::playerLeftColshape",
   EntityCreated = "rm::entityCreated",
@@ -12,6 +17,11 @@ export enum ServerInternalEventName {
 export interface IServerInternalEvents {
   [ServerInternalEventName.PlayerConnected]: (player: IPlayer) => void;
   [ServerInternalEventName.PlayerDisconnected]: (player: IPlayer) => void;
+  [ServerInternalEventName.PlayerQuit]: (player: IPlayer, exitType: string, reason: string) => void;
+  [ServerInternalEventName.PlayerDeath]: (player: IPlayer, reason: number, killer: IPlayer | null) => void;
+  [ServerInternalEventName.PlayerDamage]: (player: IPlayer, healthLoss: number, armourLoss: number) => void;
+  [ServerInternalEventName.PlayerEnterVehicle]: (player: IPlayer, vehicle: IVehicle, seat: number) => void;
+  [ServerInternalEventName.PlayerExitVehicle]: (player: IPlayer, vehicle: IVehicle) => void;
   [ServerInternalEventName.PlayerEnteredColshape]: (player: IPlayer, colshape: IColshape) => void;
   [ServerInternalEventName.PlayerLeftColshape]: (player: IPlayer, colshape: IColshape) => void;
   [ServerInternalEventName.EntityCreated]: (object: IBaseObject) => void;


### PR DESCRIPTION
## Release v0.19.0

### Client API additions

**Entity (`IEntity` / `RageEntity`)**
- `attachToEntity(target, boneIndex, offset, rotation, p9, useSoftPinning, collision, isPed, vertexIndex, fixedRot)`
- `detach(useDetachVelocity, collision)`
- `getSpeed()`
- `isPlayingAnim(dictionary, name, taskFlag)`

**Player (`IPlayer` / `RagePlayer`)**
- `clearTasksImmediately()`
- `stopAnim(dictionary, name, blendOutSpeed)`

**Players manager (`IPlayersManager` / `RagePlayersManager`)**
- `findByRemoteId(remoteId)`
- `getByRemoteId(remoteId)`

**Vehicle (`IVehicle` / `RageVehicle`)**
- `setHandling(field, value)` / `getHandling(field)`
- `setEnginePowerMultiplier(value)` / `setEngineTorqueMultiplier(value)`
- `modifyTopSpeed(value)`
- `setCheatPowerIncrease(value)`

**Streaming manager (`IStreamingManager` / `RageStreamingManager`)**
- `removeAnimationDictionary(dictionary)`
- `setFocusArea(position, offset)`
- `clearFocus()`
- `setFocusEntity(entityHandle)`

### Server — new player lifecycle events

Added to `ServerInternalEventName` / `IServerInternalEvents`:
- `PlayerQuit(player, exitType, reason)`
- `PlayerDeath(player, reason, killer)` — `killer` is resolved to an `IPlayer` (or `null`)
- `PlayerDamage(player, healthLoss, armourLoss)`
- `PlayerEnterVehicle(player, vehicle, seat)`
- `PlayerExitVehicle(player, vehicle)`

The existing `PlayerDisconnected` event remains; `PlayerQuit` is emitted alongside it with RAGEMP's `exitType` and `reason` payload.

