### PR TITLE
Release 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "rock-mod",
       "version": "0.19.0",
       "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.15"
+      },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -754,6 +757,15 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -4800,10 +4812,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "dev": true,
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
   ],
   "author": "xvetal",
   "license": "MIT",
+  "dependencies": {
+    "@swc/helpers": "^0.5.15"
+  },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/entities/common/ped/IPed.ts
+++ b/src/client/entities/common/ped/IPed.ts
@@ -30,4 +30,16 @@ export interface IPed extends IEntity {
   clearProp(componentId: number): void;
 
   getBoneCoords(boneId: number, offsetX: number, offsetY: number, offsetZ: number): IVector3D;
+
+  clearTasks(): void;
+  taskPlayAnim(
+    dictionary: string,
+    name: string,
+    blendInSpeed: number,
+    blendOutSpeed: number,
+    duration: number,
+    flag: number,
+    playbackRate: number,
+  ): void;
+  stopAnim(dictionary: string, name: string, blendOutSpeed: number): void;
 }

--- a/src/client/entities/common/ped/IPed.ts
+++ b/src/client/entities/common/ped/IPed.ts
@@ -41,5 +41,14 @@ export interface IPed extends IEntity {
     flag: number,
     playbackRate: number,
   ): void;
+  taskGoToCoordAnyMeans(
+    x: number,
+    y: number,
+    z: number,
+    speed: number,
+    walkingStyle?: number,
+    drivingFlags?: number,
+  ): void;
   stopAnim(dictionary: string, name: string, blendOutSpeed: number): void;
+  setBlockingOfNonTemporaryEvents(blocking: boolean): void;
 }

--- a/src/client/entities/common/player/IPlayer.ts
+++ b/src/client/entities/common/player/IPlayer.ts
@@ -73,4 +73,6 @@ export interface IPlayer extends IEntity {
   resetMovementClipset(blendDuration: number): void;
 
   getBoneCoords(boneId: number, offsetX: number, offsetY: number, offsetZ: number): IVector3D;
+
+  setNoCollision(otherHandle: number, thisFrameOnly: boolean): void;
 }

--- a/src/client/entities/common/vehicle/IVehicle.ts
+++ b/src/client/entities/common/vehicle/IVehicle.ts
@@ -56,4 +56,12 @@ export interface IVehicle extends IEntity {
   setEngineTorqueMultiplier(value: number): void;
   modifyTopSpeed(value: number): void;
   setCheatPowerIncrease(value: number): void;
+
+  toggleMod(modType: number, toggle: boolean): void;
+  setTyreSmokeColor(r: number, g: number, b: number): void;
+  setModColor1(paintType: number, color: number, p3: number): void;
+  setExtraColours(pearlescentColor: number, wheelColor: number): void;
+  getMaxBraking(): number;
+  getAcceleration(): number;
+  getMaxTraction(): number;
 }

--- a/src/client/entities/common/vehicle/IVehicle.ts
+++ b/src/client/entities/common/vehicle/IVehicle.ts
@@ -61,7 +61,11 @@ export interface IVehicle extends IEntity {
   setTyreSmokeColor(r: number, g: number, b: number): void;
   setModColor1(paintType: number, color: number, p3: number): void;
   setExtraColours(pearlescentColor: number, wheelColor: number): void;
+  setHeadlightColor(colorIndex: number): void;
+  setDashboardColor(colorIndex: number): void;
+  setInteriorColor(colorIndex: number): void;
   getMaxBraking(): number;
   getAcceleration(): number;
   getMaxTraction(): number;
+  getModelMaxSpeed(): number;
 }

--- a/src/client/entities/ragemp/entity/RageEntity.ts
+++ b/src/client/entities/ragemp/entity/RageEntity.ts
@@ -41,11 +41,14 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
   }
 
   public freezePosition(freeze: boolean): void {
-    this.mpEntity.freezePosition(freeze);
+    // FREEZE_ENTITY_POSITION via raw native: the RAGEMP wrapper does not consistently
+    // toggle the engine-level freeze for client-spawned entities, leaving them frozen.
+    mp.game.invoke("0x428CA6DBD1094446", this.handle, freeze);
   }
 
   public setCollision(collision: boolean, keepPhysics: boolean): void {
-    this.mpEntity.setCollision(collision, keepPhysics);
+    // SET_ENTITY_COLLISION via raw native for the same reason as freezePosition above.
+    mp.game.invoke("0x1A9205C1B9EE827F", this.handle, collision, keepPhysics);
   }
 
   public setInvincible(invincible: boolean): void {

--- a/src/client/entities/ragemp/ped/RagePed.ts
+++ b/src/client/entities/ragemp/ped/RagePed.ts
@@ -121,4 +121,20 @@ export class RagePed extends RageEntity<PedMp> implements IPed {
   public stopAnim(dictionary: string, name: string, blendOutSpeed: number): void {
     mp.game.task.stopAnimTask(this.handle, dictionary, name, blendOutSpeed);
   }
+
+  public taskGoToCoordAnyMeans(
+    x: number,
+    y: number,
+    z: number,
+    speed: number,
+    walkingStyle: number = 786603,
+    drivingFlags: number = 0xbf800000,
+  ): void {
+    mp.game.task.goToCoordAnyMeans(this.handle, x, y, z, speed, 0, false, walkingStyle, drivingFlags);
+  }
+
+  public setBlockingOfNonTemporaryEvents(blocking: boolean): void {
+    // BLOCKING_OF_NON_TEMPORARY_EVENTS — no RAGEMP wrapper, invoke native by hash
+    mp.game.invoke("0x9F8AA94D6D97DBF4", this.handle, blocking);
+  }
 }

--- a/src/client/entities/ragemp/ped/RagePed.ts
+++ b/src/client/entities/ragemp/ped/RagePed.ts
@@ -90,4 +90,35 @@ export class RagePed extends RageEntity<PedMp> implements IPed {
     const { x, y, z } = this.mpEntity.getBoneCoords(boneId, offsetX, offsetY, offsetZ);
     return new Vector3D(x, y, z);
   }
+
+  public clearTasks(): void {
+    this.mpEntity.clearTasks();
+  }
+
+  public taskPlayAnim(
+    dictionary: string,
+    name: string,
+    blendInSpeed: number,
+    blendOutSpeed: number,
+    duration: number,
+    flag: number,
+    playbackRate: number,
+  ): void {
+    this.mpEntity.taskPlayAnim(
+      dictionary,
+      name,
+      blendInSpeed,
+      blendOutSpeed,
+      duration,
+      flag,
+      playbackRate,
+      false,
+      false,
+      false,
+    );
+  }
+
+  public stopAnim(dictionary: string, name: string, blendOutSpeed: number): void {
+    mp.game.task.stopAnimTask(this.handle, dictionary, name, blendOutSpeed);
+  }
 }

--- a/src/client/entities/ragemp/player/RagePlayer.ts
+++ b/src/client/entities/ragemp/player/RagePlayer.ts
@@ -229,4 +229,8 @@ export class RagePlayer extends RageEntity<PlayerMp> implements IPlayer {
     const { x, y, z } = this.mpEntity.getBoneCoords(boneId, offsetX, offsetY, offsetZ);
     return new Vector3D(x, y, z);
   }
+
+  public setNoCollision(otherHandle: number, thisFrameOnly: boolean): void {
+    this.mpEntity.setNoCollision(otherHandle, thisFrameOnly);
+  }
 }

--- a/src/client/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehicle.ts
@@ -174,4 +174,32 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
   public setCheatPowerIncrease(value: number): void {
     mp.game.vehicle.setCheatPowerIncrease(this.handle, value);
   }
+
+  public toggleMod(modType: number, toggle: boolean): void {
+    this.mpEntity.toggleMod(modType, toggle);
+  }
+
+  public setTyreSmokeColor(r: number, g: number, b: number): void {
+    this.mpEntity.setTyreSmokeColor(r, g, b);
+  }
+
+  public setModColor1(paintType: number, color: number, p3: number): void {
+    this.mpEntity.setModColor1(paintType, color, p3);
+  }
+
+  public setExtraColours(pearlescentColor: number, wheelColor: number): void {
+    this.mpEntity.setExtraColours(pearlescentColor, wheelColor);
+  }
+
+  public getMaxBraking(): number {
+    return this.mpEntity.getMaxBraking();
+  }
+
+  public getAcceleration(): number {
+    return this.mpEntity.getAcceleration();
+  }
+
+  public getMaxTraction(): number {
+    return this.mpEntity.getMaxTraction();
+  }
 }

--- a/src/client/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehicle.ts
@@ -191,6 +191,21 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
     this.mpEntity.setExtraColours(pearlescentColor, wheelColor);
   }
 
+  public setHeadlightColor(colorIndex: number): void {
+    // _SET_VEHICLE_HEADLIGHT_COLOUR — no RAGEMP wrapper, invoke native by hash
+    mp.game.invoke("0xE41033B25D003A07", this.handle, colorIndex);
+  }
+
+  public setDashboardColor(colorIndex: number): void {
+    // SET_VEHICLE_DASHBOARD_COLOUR — no RAGEMP wrapper, invoke native by hash
+    mp.game.invoke("0x6089CDF6A57F326C", this.handle, colorIndex);
+  }
+
+  public setInteriorColor(colorIndex: number): void {
+    // SET_VEHICLE_INTERIOR_COLOUR — no RAGEMP wrapper, invoke native by hash
+    mp.game.invoke("0xF40DD601A65F7F19", this.handle, colorIndex);
+  }
+
   public getMaxBraking(): number {
     return this.mpEntity.getMaxBraking();
   }
@@ -201,5 +216,9 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
 
   public getMaxTraction(): number {
     return this.mpEntity.getMaxTraction();
+  }
+
+  public getModelMaxSpeed(): number {
+    return mp.game.vehicle.getVehicleModelMaxSpeed(this.mpEntity.model);
   }
 }

--- a/src/client/game/common/graphics/IGraphicsManager.ts
+++ b/src/client/game/common/graphics/IGraphicsManager.ts
@@ -13,4 +13,6 @@ export interface IGraphicsManager {
   world3dToScreen2d(position: IVector3D): IVector2D | null;
   startScreenEffect(effectName: string, duration: number, looped: boolean): void;
   stopScreenEffect(effectName: string): void;
+  getSafeZoneSize(): number;
+  getActiveScreenResolution(): IVector2D;
 }

--- a/src/client/game/common/streaming/IStreamingManager.ts
+++ b/src/client/game/common/streaming/IStreamingManager.ts
@@ -5,6 +5,8 @@ export interface IStreamingManager {
   hasAnimationDictionaryLoaded(dictionary: string): boolean;
   removeAnimationDictionary(dictionary: string): void;
   isModelInCdimage(model: string): boolean;
+  requestModel(modelHash: number): void;
+  hasModelLoaded(modelHash: number): boolean;
   requestIpl(iplName: string): void;
   removeIpl(iplName: string): void;
   setFocusArea(position: IVector3D, offset: IVector3D): void;

--- a/src/client/game/ragemp/graphics/RageGraphicsManager.ts
+++ b/src/client/game/ragemp/graphics/RageGraphicsManager.ts
@@ -34,4 +34,13 @@ export class RageGraphicsManager implements IGraphicsManager {
   public stopScreenEffect(effectName: string): void {
     mp.game.graphics.stopScreenEffect(effectName);
   }
+
+  public getSafeZoneSize(): number {
+    return mp.game.graphics.getSafeZoneSize();
+  }
+
+  public getActiveScreenResolution(): IVector2D {
+    const result = mp.game.graphics.getActiveScreenResolution();
+    return new Vector2D(result.x, result.y);
+  }
 }

--- a/src/client/game/ragemp/streaming/RageStreamingManager.ts
+++ b/src/client/game/ragemp/streaming/RageStreamingManager.ts
@@ -19,6 +19,14 @@ export class RageStreamingManager implements IStreamingManager {
     return mp.game.streaming.isModelInCdimage(modelHash);
   }
 
+  public requestModel(modelHash: number): void {
+    mp.game.streaming.requestModel(modelHash);
+  }
+
+  public hasModelLoaded(modelHash: number): boolean {
+    return mp.game.streaming.hasModelLoaded(modelHash);
+  }
+
   public requestIpl(iplName: string): void {
     mp.game.streaming.requestIpl(iplName);
   }


### PR DESCRIPTION
## Rock-Mod 0.20.0

This release expands the client-side RageMP API with new entity, vehicle, ped, graphics, and streaming capabilities.

### Added

- Added new ped task APIs:
  - `clearTasks`
  - `taskPlayAnim`
  - `taskGoToCoordAnyMeans`
  - `stopAnim`
  - `setBlockingOfNonTemporaryEvents`

- Added new vehicle customization and performance APIs:
  - `toggleMod`
  - `setTyreSmokeColor`
  - `setModColor1`
  - `setExtraColours`
  - `setHeadlightColor`
  - `setDashboardColor`
  - `setInteriorColor`
  - `getMaxBraking`
  - `getAcceleration`
  - `getMaxTraction`
  - `getModelMaxSpeed`

- Added `setNoCollision` to the client player API.
- Added graphics helpers for safe zone size and active screen resolution.
- Added streaming helpers for requesting models and checking model load state.

### Fixed

- Fixed client entity `freezePosition` and `setCollision` behavior for RageMP by using native calls where the RageMP wrapper may not consistently apply the engine-level state.