### PR TITLE
Release 0.22.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,14 @@ on:
     branches:
       - stable
       - testing
-      - development
+      - dev
   pull_request:
     branches:
       - stable
       - testing
-      - development
+      - dev
+permissions:
+  contents: read
 jobs:
   main:
     name: Check
@@ -21,10 +23,12 @@ jobs:
     env:
       NODE_ENV: cicd
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: package-lock.json
       - name: Install Dependencies
         run: npm ci
       - name: Build project

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -16,6 +19,8 @@ jobs:
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run build
       - run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@swc/helpers": "^0.5.15"
       },
       "devDependencies": {
-        "@classic-mp/types": "^1.4.1",
+        "@classic-mp/types": "^1.5.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@classic-mp/types": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.4.1.tgz",
-      "integrity": "sha512-uB5CEILZ1368xjE5A9IST4DK+06QUQL6hjsLCSN5K3wT94hc4tdkI9I0SJ671TJ2jdIvl/5iosKi8qQtg2V0qA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.5.0.tgz",
+      "integrity": "sha512-Ahn/mZtIYULTZsIKFO6ex0R5qLhK/m33+pgG3Y/enyOX/meBRRjK20i/1X9KdoZmR4BZyeynN5GJWp9R0wi24w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@swc/helpers": "^0.5.15"
       },
       "devDependencies": {
-        "@classic-mp/types": "^1.5.0",
+        "@classic-mp/types": "^1.6.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@classic-mp/types": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.5.0.tgz",
-      "integrity": "sha512-Ahn/mZtIYULTZsIKFO6ex0R5qLhK/m33+pgG3Y/enyOX/meBRRjK20i/1X9KdoZmR4BZyeynN5GJWp9R0wi24w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.6.0.tgz",
+      "integrity": "sha512-PF9OcadwbhNxZeQZoqnqUI5Czw603iljB0e3ub3DqJgo0bPK3qVfFsL6fR+rzXbvGbP1KjOc0X0rrZLipyL4Zw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@swc/helpers": "^0.5.15"
   },
   "devDependencies": {
-    "@classic-mp/types": "^1.4.1",
+    "@classic-mp/types": "^1.5.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@swc/helpers": "^0.5.15"
   },
   "devDependencies": {
-    "@classic-mp/types": "^1.5.0",
+    "@classic-mp/types": "^1.6.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/src/client/entities/ccmp/blip/CCMPBlip.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlip.ts
@@ -1,0 +1,125 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { type Blip as CcmpBlip } from "@classic-mp/types/client";
+import { BaseObjectType, type IBlipColor, type IBlipSprite } from "@shared/entities";
+import { type IVector3D, Vector3D } from "@shared/common/utils";
+import { type IBlip } from "../../common/blip/IBlip";
+
+const notImplemented = (memberName: string): never => {
+  throw new Error(`CCMPBlip.${memberName}: not implemented`);
+};
+
+export class CCMPBlip implements IBlip {
+  private _destroyed = false;
+
+  public constructor(
+    private readonly _ccmpBlip: CcmpBlip,
+    private readonly _onDestroy: (blip: CCMPBlip) => void = () => {},
+  ) {}
+
+  public get id(): number {
+    return this._ccmpBlip.id;
+  }
+
+  public get remoteId(): number {
+    return this._ccmpBlip.remoteId;
+  }
+
+  public get type(): BaseObjectType {
+    return BaseObjectType.Blip;
+  }
+
+  public get isExists(): boolean {
+    return !this._destroyed && this._ccmpBlip.isExists;
+  }
+
+  public get handle(): number {
+    return this._ccmpBlip.handle;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._onDestroy(this);
+  }
+
+  public get position(): Vector3D {
+    const { x, y, z } = this._ccmpBlip.position;
+    return new Vector3D(x, y, z);
+  }
+
+  public get dimension(): number {
+    return this._ccmpBlip.dimension;
+  }
+
+  public setPosition(_value: IVector3D): void {
+    notImplemented("setPosition");
+  }
+
+  public setDimension(_value: number): void {
+    notImplemented("setDimension");
+  }
+
+  public setCoords(
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xAxis: boolean,
+    _yAxis: boolean,
+    _zAxis: boolean,
+    _clearArea: boolean,
+  ): void {
+    notImplemented("setCoords");
+  }
+
+  public get name(): string {
+    return this._ccmpBlip.name;
+  }
+
+  public get sprite(): IBlipSprite {
+    return this._ccmpBlip.sprite as IBlipSprite;
+  }
+
+  public get color(): number {
+    return this._ccmpBlip.color;
+  }
+
+  public get alpha(): number {
+    return this._ccmpBlip.alpha;
+  }
+
+  public get scale(): number {
+    return this._ccmpBlip.scale;
+  }
+
+  public get drawDistance(): number {
+    return this._ccmpBlip.drawDistance;
+  }
+
+  public get shortRange(): boolean {
+    return this._ccmpBlip.shortRange;
+  }
+
+  public get rotation(): number {
+    return this._ccmpBlip.rotation;
+  }
+
+  public setSprite(_value: IBlipSprite): void {
+    notImplemented("setSprite");
+  }
+
+  public setColor(_value: IBlipColor): void {
+    notImplemented("setColor");
+  }
+
+  public setAlpha(_value: number): void {
+    notImplemented("setAlpha");
+  }
+
+  public setShowHeadingIndicator(_value: boolean): void {
+    notImplemented("setShowHeadingIndicator");
+  }
+
+  public setRotation(_value: number): void {
+    notImplemented("setRotation");
+  }
+}

--- a/src/client/entities/ccmp/blip/CCMPBlip.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlip.ts
@@ -20,7 +20,7 @@ export class CCMPBlip implements IBlip {
     return this._ccmpBlip.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpBlip.remoteId;
   }
 

--- a/src/client/entities/ccmp/blip/CCMPBlip.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlip.ts
@@ -39,6 +39,7 @@ export class CCMPBlip implements IBlip {
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ccmpBlip.destroy();
     this._onDestroy(this);
   }
 

--- a/src/client/entities/ccmp/blip/CCMPBlip.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlip.ts
@@ -104,6 +104,43 @@ export class CCMPBlip implements IBlip {
     return this._ccmpBlip.rotation;
   }
 
+  public getVariable(name: string): unknown | null {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Blip, remoteId, name);
+    return value === undefined ? null : value;
+  }
+
+  public getSyncedMeta(key: string): unknown | undefined {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Blip, remoteId, key);
+  }
+
+  public hasSyncedMeta(key: string): boolean {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Blip, remoteId, key);
+  }
+
+  public getSyncedMetaKeys(): readonly string[] {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Blip, remoteId);
+  }
+
   public setSprite(_value: IBlipSprite): void {
     notImplemented("setSprite");
   }

--- a/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
@@ -9,6 +9,8 @@ import { CCMPBlip } from "./CCMPBlip";
 export class CCMPBlipsManager implements IBlipsManager {
   private readonly _blips = new Map<number, CCMPBlip>();
 
+  private readonly _blipsByRemoteId = new Map<number, CCMPBlip>();
+
   private readonly _iterator: IWorldObjectsIterator<CCMPBlip> = {
     all: (): IterableIterator<CCMPBlip> => this._filter(() => true),
     dimension: (value: number): IterableIterator<CCMPBlip> => this._filter((blip) => blip.dimension === value),
@@ -38,9 +40,7 @@ export class CCMPBlipsManager implements IBlipsManager {
     this._pruneDestroyed();
 
     for (const ccmpBlip of ccmp.blips.all) {
-      if (!this._blips.has(ccmpBlip.id)) {
-        this._register(ccmpBlip);
-      }
+      this._register(ccmpBlip);
     }
   }
 
@@ -65,7 +65,7 @@ export class CCMPBlipsManager implements IBlipsManager {
   public findByID(id: number): CCMPBlip | null {
     const blip = this._blips.get(id) ?? null;
     if (blip && !blip.isExists) {
-      this._blips.delete(id);
+      this._unregister(blip);
     } else if (blip) {
       return blip;
     }
@@ -87,7 +87,19 @@ export class CCMPBlipsManager implements IBlipsManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPBlip | null {
-    return this.findByID(remoteId);
+    const blip = this._blipsByRemoteId.get(remoteId) ?? null;
+    if (blip && !blip.isExists) {
+      this._unregister(blip);
+    } else if (blip) {
+      return blip;
+    }
+
+    const ccmpBlip = ccmp.blips.getByRemoteId(remoteId);
+    if (!ccmpBlip) {
+      return null;
+    }
+
+    return this._register(ccmpBlip);
   }
 
   public getByRemoteID(remoteId: number): CCMPBlip {
@@ -109,16 +121,37 @@ export class CCMPBlipsManager implements IBlipsManager {
   }
 
   private _register(ccmpBlip: CcmpBlip): CCMPBlip {
-    const existingBlip = this._blips.get(ccmpBlip.id) ?? null;
+    const existingBlip = this._findRegistered(ccmpBlip);
     if (existingBlip && existingBlip.isExists) {
       return existingBlip;
     }
+    if (existingBlip) {
+      this._unregister(existingBlip);
+    }
 
     const blip = new CCMPBlip(ccmpBlip, (destroyedBlip) => {
-      this._blips.delete(destroyedBlip.id);
+      this._unregister(destroyedBlip);
     });
     this._blips.set(blip.id, blip);
+    if (blip.remoteId !== null) {
+      this._blipsByRemoteId.set(blip.remoteId, blip);
+    }
     return blip;
+  }
+
+  private _unregister(blip: CCMPBlip): void {
+    this._blips.delete(blip.id);
+    if (blip.remoteId !== null) {
+      this._blipsByRemoteId.delete(blip.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpBlip: CcmpBlip): CCMPBlip | null {
+    return (
+      (ccmpBlip.remoteId === null ? null : (this._blipsByRemoteId.get(ccmpBlip.remoteId) ?? null)) ??
+      this._blips.get(ccmpBlip.id) ??
+      null
+    );
   }
 
   private _registerLifecycleEvents(): void {
@@ -130,9 +163,9 @@ export class CCMPBlipsManager implements IBlipsManager {
 
     ccmp.on("blipDestroyed", (ccmpBlip: CcmpBlip | null) => {
       if (!ccmpBlip) return;
-      const blip = this._blips.get(ccmpBlip.id) ?? this._register(ccmpBlip);
+      const blip = this._findRegistered(ccmpBlip) ?? this._register(ccmpBlip);
       this._events.emitInternal(ClientInternalEventName.EntityDestroyed, blip);
-      this._blips.delete(blip.id);
+      this._unregister(blip);
     });
 
     ccmp.on("blipStreamIn", (ccmpBlip: CcmpBlip | null) => {
@@ -143,7 +176,7 @@ export class CCMPBlipsManager implements IBlipsManager {
 
     ccmp.on("blipStreamOut", (ccmpBlip: CcmpBlip | null) => {
       if (!ccmpBlip) return;
-      const blip = this._blips.get(ccmpBlip.id) ?? this._register(ccmpBlip);
+      const blip = this._findRegistered(ccmpBlip) ?? this._register(ccmpBlip);
       this._events.emitInternal(ClientInternalEventName.EntityStreamOut, blip);
     });
   }
@@ -151,7 +184,7 @@ export class CCMPBlipsManager implements IBlipsManager {
   private *_filter(predicate: (blip: CCMPBlip) => boolean): IterableIterator<CCMPBlip> {
     for (const blip of this._blips.values()) {
       if (!blip.isExists) {
-        this._blips.delete(blip.id);
+        this._unregister(blip);
         continue;
       }
 
@@ -164,7 +197,7 @@ export class CCMPBlipsManager implements IBlipsManager {
   private _pruneDestroyed(): void {
     for (const blip of this._blips.values()) {
       if (!blip.isExists) {
-        this._blips.delete(blip.id);
+        this._unregister(blip);
       }
     }
   }

--- a/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
@@ -30,10 +30,34 @@ export class CCMPBlipsManager implements IBlipsManager {
   }
 
   public create(options: IBlipCreateOptions): CCMPBlip {
-    void options;
-    throw new Error(
-      "CCMPBlipsManager.create: client-side blip creation is not supported by CCMP. Use server-side ccmp.blips.create.",
-    );
+    const createOptions: {
+      dimension?: number;
+      alpha?: number;
+      color?: number;
+      drawDistance?: number;
+      name?: string;
+      rotation?: number;
+      scale?: number;
+      shortRange?: boolean;
+    } = {
+      dimension: options.dimension,
+    };
+
+    if (options.alpha !== undefined) createOptions.alpha = options.alpha;
+    if (options.color !== undefined) createOptions.color = options.color;
+    if (options.drawDistance !== undefined) createOptions.drawDistance = options.drawDistance;
+    if (options.name !== undefined) createOptions.name = options.name;
+    if (options.rotation !== undefined) createOptions.rotation = options.rotation;
+    if (options.scale !== undefined) createOptions.scale = options.scale;
+    if (options.shortRange !== undefined) createOptions.shortRange = options.shortRange;
+
+    const ccmpBlip = ccmp.blips.create(options.sprite, options.position, createOptions);
+
+    if (!ccmpBlip) {
+      throw new Error(`CCMPBlipsManager.create: ccmp.blips.create failed for sprite "${options.sprite}"`);
+    }
+
+    return this._register(ccmpBlip);
   }
 
   public syncWithMpPool(): void {

--- a/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
+++ b/src/client/entities/ccmp/blip/CCMPBlipsManager.ts
@@ -1,0 +1,171 @@
+import { type Blip as CcmpBlip } from "@classic-mp/types/client";
+import { type CCMPEventsManager } from "@RockMod/client/net/ccmp/events/CCMPEventsManager";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
+import { type IBlipCreateOptions, type IBlipsManager } from "../../common/blip/IBlipsManager";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { CCMPBlip } from "./CCMPBlip";
+
+export class CCMPBlipsManager implements IBlipsManager {
+  private readonly _blips = new Map<number, CCMPBlip>();
+
+  private readonly _iterator: IWorldObjectsIterator<CCMPBlip> = {
+    all: (): IterableIterator<CCMPBlip> => this._filter(() => true),
+    dimension: (value: number): IterableIterator<CCMPBlip> => this._filter((blip) => blip.dimension === value),
+    range2D: (center: Vector2D, range: number): IterableIterator<CCMPBlip> =>
+      this._filter((blip) => {
+        const position = blip.position;
+        const squaredDistance = (position.x - center.x) ** 2 + (position.y - center.y) ** 2;
+        return squaredDistance <= range * range;
+      }),
+    range3D: (center: Vector3D, range: number): IterableIterator<CCMPBlip> =>
+      this._filter((blip) => blip.position.isInRange(center, range)),
+  };
+
+  public constructor(private readonly _events: CCMPEventsManager) {
+    this._registerLifecycleEvents();
+    this.syncWithMpPool();
+  }
+
+  public create(options: IBlipCreateOptions): CCMPBlip {
+    void options;
+    throw new Error(
+      "CCMPBlipsManager.create: client-side blip creation is not supported by CCMP. Use server-side ccmp.blips.create.",
+    );
+  }
+
+  public syncWithMpPool(): void {
+    this._pruneDestroyed();
+
+    for (const ccmpBlip of ccmp.blips.all) {
+      if (!this._blips.has(ccmpBlip.id)) {
+        this._register(ccmpBlip);
+      }
+    }
+  }
+
+  public registerById(id: number): CCMPBlip {
+    const existingBlip = this.findByID(id);
+    if (existingBlip) {
+      return existingBlip;
+    }
+
+    const ccmpBlip = ccmp.blips.getById(id);
+    if (!ccmpBlip) {
+      throw new Error(`CCMPBlipsManager.registerById(${id}): blip not found.`);
+    }
+
+    return this._register(ccmpBlip);
+  }
+
+  public unregisterById(id: number): CCMPBlip {
+    return this.deleteById(id);
+  }
+
+  public findByID(id: number): CCMPBlip | null {
+    const blip = this._blips.get(id) ?? null;
+    if (blip && !blip.isExists) {
+      this._blips.delete(id);
+    } else if (blip) {
+      return blip;
+    }
+
+    const ccmpBlip = ccmp.blips.getById(id);
+    if (!ccmpBlip) {
+      return null;
+    }
+
+    return this._register(ccmpBlip);
+  }
+
+  public getByID(id: number): CCMPBlip {
+    const blip = this.findByID(id);
+    if (!blip) {
+      throw new Error(`CCMPBlipsManager.getByID(${id}): blip not found.`);
+    }
+    return blip;
+  }
+
+  public findByRemoteID(remoteId: number): CCMPBlip | null {
+    return this.findByID(remoteId);
+  }
+
+  public getByRemoteID(remoteId: number): CCMPBlip {
+    const blip = this.findByRemoteID(remoteId);
+    if (!blip) {
+      throw new Error(`CCMPBlipsManager.getByRemoteID(${remoteId}): blip not found.`);
+    }
+    return blip;
+  }
+
+  public deleteById(id: number): CCMPBlip {
+    const blip = this.getByID(id);
+    blip.destroy();
+    return blip;
+  }
+
+  public get iterator(): IWorldObjectsIterator<CCMPBlip> {
+    return this._iterator;
+  }
+
+  private _register(ccmpBlip: CcmpBlip): CCMPBlip {
+    const existingBlip = this._blips.get(ccmpBlip.id) ?? null;
+    if (existingBlip && existingBlip.isExists) {
+      return existingBlip;
+    }
+
+    const blip = new CCMPBlip(ccmpBlip, (destroyedBlip) => {
+      this._blips.delete(destroyedBlip.id);
+    });
+    this._blips.set(blip.id, blip);
+    return blip;
+  }
+
+  private _registerLifecycleEvents(): void {
+    ccmp.on("blipCreated", (ccmpBlip: CcmpBlip | null) => {
+      if (!ccmpBlip) return;
+      const blip = this._register(ccmpBlip);
+      this._events.emitInternal(ClientInternalEventName.EntityCreated, blip);
+    });
+
+    ccmp.on("blipDestroyed", (ccmpBlip: CcmpBlip | null) => {
+      if (!ccmpBlip) return;
+      const blip = this._blips.get(ccmpBlip.id) ?? this._register(ccmpBlip);
+      this._events.emitInternal(ClientInternalEventName.EntityDestroyed, blip);
+      this._blips.delete(blip.id);
+    });
+
+    ccmp.on("blipStreamIn", (ccmpBlip: CcmpBlip | null) => {
+      if (!ccmpBlip) return;
+      const blip = this._register(ccmpBlip);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamIn, blip);
+    });
+
+    ccmp.on("blipStreamOut", (ccmpBlip: CcmpBlip | null) => {
+      if (!ccmpBlip) return;
+      const blip = this._blips.get(ccmpBlip.id) ?? this._register(ccmpBlip);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamOut, blip);
+    });
+  }
+
+  private *_filter(predicate: (blip: CCMPBlip) => boolean): IterableIterator<CCMPBlip> {
+    for (const blip of this._blips.values()) {
+      if (!blip.isExists) {
+        this._blips.delete(blip.id);
+        continue;
+      }
+
+      if (predicate(blip)) {
+        yield blip;
+      }
+    }
+  }
+
+  private _pruneDestroyed(): void {
+    for (const blip of this._blips.values()) {
+      if (!blip.isExists) {
+        this._blips.delete(blip.id);
+      }
+    }
+  }
+}

--- a/src/client/entities/ccmp/camera/CCMPCamera.ts
+++ b/src/client/entities/ccmp/camera/CCMPCamera.ts
@@ -10,8 +10,8 @@ export class CCMPCamera implements ICamera {
     return this._camera.id;
   }
 
-  public get remoteId(): number {
-    return 0;
+  public get remoteId(): number | null {
+    return null;
   }
 
   public get type(): BaseObjectType {

--- a/src/client/entities/ccmp/camera/CCMPCameraManager.ts
+++ b/src/client/entities/ccmp/camera/CCMPCameraManager.ts
@@ -49,7 +49,8 @@ export class CCMPCameraManager implements ICameraManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPCamera | null {
-    return remoteId === 0 ? null : this.findByID(remoteId);
+    void remoteId;
+    return null;
   }
 
   public deleteById(id: number): CCMPCamera {

--- a/src/client/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshape.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { type Colshape as CcmpColshape } from "@classic-mp/types/client";
+import { BaseObjectType } from "@shared/entities";
+import { type IVector3D, Vector3D } from "@shared/common/utils";
+import { type IColshape } from "../../common/colshape/IColshape";
+
+const notImplemented = (memberName: string): never => {
+  throw new Error(`CCMPColshape.${memberName}: not implemented`);
+};
+
+export class CCMPColshape implements IColshape {
+  private _destroyed = false;
+
+  public constructor(
+    private readonly _ccmpColshape: CcmpColshape,
+    private readonly _onDestroy: (colshape: CCMPColshape) => void = () => {},
+  ) {}
+
+  public get id(): number {
+    return this._ccmpColshape.id;
+  }
+
+  public get remoteId(): number {
+    return this._ccmpColshape.remoteId;
+  }
+
+  public get type(): BaseObjectType {
+    return BaseObjectType.Colshape;
+  }
+
+  public get isExists(): boolean {
+    return !this._destroyed && this._ccmpColshape.isExists;
+  }
+
+  public get handle(): number {
+    return 0;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._onDestroy(this);
+  }
+
+  public get position(): Vector3D {
+    const { x, y, z } = this._ccmpColshape.position;
+    return new Vector3D(x, y, z);
+  }
+
+  public get dimension(): number {
+    return this._ccmpColshape.dimension;
+  }
+
+  public get key(): string | undefined {
+    const value = this.getSyncedMeta("key");
+    return typeof value === "string" ? value : undefined;
+  }
+
+  public setPosition(_value: IVector3D): void {
+    notImplemented("setPosition");
+  }
+
+  public setDimension(_value: number): void {
+    notImplemented("setDimension");
+  }
+
+  public setCoords(
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xAxis: boolean,
+    _yAxis: boolean,
+    _zAxis: boolean,
+    _clearArea: boolean,
+  ): void {
+    notImplemented("setCoords");
+  }
+
+  public getVariable(name: string): unknown | null {
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, name);
+    return value === undefined ? null : value;
+  }
+
+  public getSyncedMeta(key: string): unknown | undefined {
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, key);
+  }
+
+  public hasSyncedMeta(key: string): boolean {
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, key);
+  }
+
+  public getSyncedMetaKeys(): readonly string[] {
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId);
+  }
+}

--- a/src/client/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshape.ts
@@ -20,7 +20,7 @@ export class CCMPColshape implements IColshape {
     return this._ccmpColshape.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpColshape.remoteId;
   }
 
@@ -77,19 +77,39 @@ export class CCMPColshape implements IColshape {
   }
 
   public getVariable(name: string): unknown | null {
-    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, name);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, remoteId, name);
     return value === undefined ? null : value;
   }
 
   public getSyncedMeta(key: string): unknown | undefined {
-    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, remoteId, key);
   }
 
   public hasSyncedMeta(key: string): boolean {
-    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Colshape, remoteId, key);
   }
 
   public getSyncedMetaKeys(): readonly string[] {
-    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Colshape, this.remoteId);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Colshape, remoteId);
   }
 }

--- a/src/client/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshape.ts
@@ -39,6 +39,7 @@ export class CCMPColshape implements IColshape {
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ccmpColshape.destroy();
     this._onDestroy(this);
   }
 

--- a/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
@@ -38,24 +38,26 @@ export class CCMPColshapesManager implements IColshapesManager {
   }
 
   public createCircle(options: ICircleColshapeCreateOptions): CCMPColshape {
-    void options;
-    throw new Error(
-      "CCMPColshapesManager.createCircle: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCircle.",
-    );
+    const ccmpColshape = ccmp.colshapes.createCircle(options.position, options.range, {
+      dimension: options.dimension,
+    });
+    return this._register(ccmpColshape);
   }
 
   public createCuboid(options: ICuboidColshapeCreateOptions): CCMPColshape {
-    void options;
-    throw new Error(
-      "CCMPColshapesManager.createCuboid: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCube.",
+    const ccmpColshape = ccmp.colshapes.createCuboid(
+      options.position,
+      { x: options.width, y: options.depth, z: options.height },
+      { dimension: options.dimension },
     );
+    return this._register(ccmpColshape);
   }
 
   public createCylinder(options: ICylinderColshapeCreateOptions): CCMPColshape {
-    void options;
-    throw new Error(
-      "CCMPColshapesManager.createCylinder: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCylinder.",
-    );
+    const ccmpColshape = ccmp.colshapes.createCylinder(options.position, options.range, options.height, {
+      dimension: options.dimension,
+    });
+    return this._register(ccmpColshape);
   }
 
   public createRectangle(options: IRectangleColshapeCreateOptions): CCMPColshape {
@@ -64,10 +66,10 @@ export class CCMPColshapesManager implements IColshapesManager {
   }
 
   public createSphere(options: ISphereColshapeCreateOptions): CCMPColshape {
-    void options;
-    throw new Error(
-      "CCMPColshapesManager.createSphere: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createSphere.",
-    );
+    const ccmpColshape = ccmp.colshapes.createSphere(options.position, options.range, {
+      dimension: options.dimension,
+    });
+    return this._register(ccmpColshape);
   }
 
   public syncWithMpPool(): void {

--- a/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
@@ -16,6 +16,8 @@ import { CCMPColshape } from "./CCMPColshape";
 export class CCMPColshapesManager implements IColshapesManager {
   private readonly _colshapes = new Map<number, CCMPColshape>();
 
+  private readonly _colshapesByRemoteId = new Map<number, CCMPColshape>();
+
   private readonly _iterator: IWorldObjectsIterator<CCMPColshape> = {
     all: (): IterableIterator<CCMPColshape> => this._filter(() => true),
     dimension: (value: number): IterableIterator<CCMPColshape> =>
@@ -72,9 +74,7 @@ export class CCMPColshapesManager implements IColshapesManager {
     this._pruneDestroyed();
 
     for (const ccmpColshape of ccmp.colshapes.all) {
-      if (!this._colshapes.has(ccmpColshape.id)) {
-        this._register(ccmpColshape);
-      }
+      this._register(ccmpColshape);
     }
   }
 
@@ -99,7 +99,7 @@ export class CCMPColshapesManager implements IColshapesManager {
   public findByID(id: number): CCMPColshape | null {
     const colshape = this._colshapes.get(id) ?? null;
     if (colshape && !colshape.isExists) {
-      this._colshapes.delete(id);
+      this._unregister(colshape);
     } else if (colshape) {
       return colshape;
     }
@@ -121,7 +121,19 @@ export class CCMPColshapesManager implements IColshapesManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPColshape | null {
-    return this.findByID(remoteId);
+    const colshape = this._colshapesByRemoteId.get(remoteId) ?? null;
+    if (colshape && !colshape.isExists) {
+      this._unregister(colshape);
+    } else if (colshape) {
+      return colshape;
+    }
+
+    const ccmpColshape = ccmp.colshapes.getByRemoteId(remoteId);
+    if (!ccmpColshape) {
+      return null;
+    }
+
+    return this._register(ccmpColshape);
   }
 
   public getByRemoteID(remoteId: number): CCMPColshape {
@@ -143,16 +155,37 @@ export class CCMPColshapesManager implements IColshapesManager {
   }
 
   private _register(ccmpColshape: CcmpColshape): CCMPColshape {
-    const existingColshape = this._colshapes.get(ccmpColshape.id) ?? null;
+    const existingColshape = this._findRegistered(ccmpColshape);
     if (existingColshape && existingColshape.isExists) {
       return existingColshape;
     }
+    if (existingColshape) {
+      this._unregister(existingColshape);
+    }
 
     const colshape = new CCMPColshape(ccmpColshape, (destroyedColshape) => {
-      this._colshapes.delete(destroyedColshape.id);
+      this._unregister(destroyedColshape);
     });
     this._colshapes.set(colshape.id, colshape);
+    if (colshape.remoteId !== null) {
+      this._colshapesByRemoteId.set(colshape.remoteId, colshape);
+    }
     return colshape;
+  }
+
+  private _unregister(colshape: CCMPColshape): void {
+    this._colshapes.delete(colshape.id);
+    if (colshape.remoteId !== null) {
+      this._colshapesByRemoteId.delete(colshape.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpColshape: CcmpColshape): CCMPColshape | null {
+    return (
+      (ccmpColshape.remoteId === null ? null : (this._colshapesByRemoteId.get(ccmpColshape.remoteId) ?? null)) ??
+      this._colshapes.get(ccmpColshape.id) ??
+      null
+    );
   }
 
   private _registerLifecycleEvents(): void {
@@ -164,9 +197,9 @@ export class CCMPColshapesManager implements IColshapesManager {
 
     ccmp.on("colshapeDestroyed", (ccmpColshape: CcmpColshape | null) => {
       if (!ccmpColshape) return;
-      const colshape = this._colshapes.get(ccmpColshape.id) ?? this._register(ccmpColshape);
+      const colshape = this._findRegistered(ccmpColshape) ?? this._register(ccmpColshape);
       this._events.emitInternal(ClientInternalEventName.EntityDestroyed, colshape);
-      this._colshapes.delete(colshape.id);
+      this._unregister(colshape);
     });
 
     ccmp.on("colshapeStreamIn", (ccmpColshape: CcmpColshape | null) => {
@@ -177,7 +210,7 @@ export class CCMPColshapesManager implements IColshapesManager {
 
     ccmp.on("colshapeStreamOut", (ccmpColshape: CcmpColshape | null) => {
       if (!ccmpColshape) return;
-      const colshape = this._colshapes.get(ccmpColshape.id) ?? this._register(ccmpColshape);
+      const colshape = this._findRegistered(ccmpColshape) ?? this._register(ccmpColshape);
       this._events.emitInternal(ClientInternalEventName.EntityStreamOut, colshape);
     });
   }
@@ -185,7 +218,7 @@ export class CCMPColshapesManager implements IColshapesManager {
   private *_filter(predicate: (colshape: CCMPColshape) => boolean): IterableIterator<CCMPColshape> {
     for (const colshape of this._colshapes.values()) {
       if (!colshape.isExists) {
-        this._colshapes.delete(colshape.id);
+        this._unregister(colshape);
         continue;
       }
 
@@ -198,7 +231,7 @@ export class CCMPColshapesManager implements IColshapesManager {
   private _pruneDestroyed(): void {
     for (const colshape of this._colshapes.values()) {
       if (!colshape.isExists) {
-        this._colshapes.delete(colshape.id);
+        this._unregister(colshape);
       }
     }
   }

--- a/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshapesManager.ts
@@ -1,0 +1,205 @@
+import { type Colshape as CcmpColshape } from "@classic-mp/types/client";
+import { type CCMPEventsManager } from "@RockMod/client/net/ccmp/events/CCMPEventsManager";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
+import {
+  type ICircleColshapeCreateOptions,
+  type IColshapesManager,
+  type ICuboidColshapeCreateOptions,
+  type ICylinderColshapeCreateOptions,
+  type IRectangleColshapeCreateOptions,
+  type ISphereColshapeCreateOptions,
+} from "../../common/colshape/IColshapesManager";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { CCMPColshape } from "./CCMPColshape";
+
+export class CCMPColshapesManager implements IColshapesManager {
+  private readonly _colshapes = new Map<number, CCMPColshape>();
+
+  private readonly _iterator: IWorldObjectsIterator<CCMPColshape> = {
+    all: (): IterableIterator<CCMPColshape> => this._filter(() => true),
+    dimension: (value: number): IterableIterator<CCMPColshape> =>
+      this._filter((colshape) => colshape.dimension === value),
+    range2D: (center: Vector2D, range: number): IterableIterator<CCMPColshape> =>
+      this._filter((colshape) => {
+        const position = colshape.position;
+        const squaredDistance = (position.x - center.x) ** 2 + (position.y - center.y) ** 2;
+        return squaredDistance <= range * range;
+      }),
+    range3D: (center: Vector3D, range: number): IterableIterator<CCMPColshape> =>
+      this._filter((colshape) => colshape.position.isInRange(center, range)),
+  };
+
+  public constructor(private readonly _events: CCMPEventsManager) {
+    this._registerLifecycleEvents();
+    this.syncWithMpPool();
+  }
+
+  public createCircle(options: ICircleColshapeCreateOptions): CCMPColshape {
+    void options;
+    throw new Error(
+      "CCMPColshapesManager.createCircle: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCircle.",
+    );
+  }
+
+  public createCuboid(options: ICuboidColshapeCreateOptions): CCMPColshape {
+    void options;
+    throw new Error(
+      "CCMPColshapesManager.createCuboid: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCube.",
+    );
+  }
+
+  public createCylinder(options: ICylinderColshapeCreateOptions): CCMPColshape {
+    void options;
+    throw new Error(
+      "CCMPColshapesManager.createCylinder: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createCylinder.",
+    );
+  }
+
+  public createRectangle(options: IRectangleColshapeCreateOptions): CCMPColshape {
+    void options;
+    throw new Error("CCMPColshapesManager.createRectangle: not supported by CCMP");
+  }
+
+  public createSphere(options: ISphereColshapeCreateOptions): CCMPColshape {
+    void options;
+    throw new Error(
+      "CCMPColshapesManager.createSphere: client-side colshape creation is not supported by CCMP. Use server-side ccmp.colshapes.createSphere.",
+    );
+  }
+
+  public syncWithMpPool(): void {
+    this._pruneDestroyed();
+
+    for (const ccmpColshape of ccmp.colshapes.all) {
+      if (!this._colshapes.has(ccmpColshape.id)) {
+        this._register(ccmpColshape);
+      }
+    }
+  }
+
+  public registerById(id: number): CCMPColshape {
+    const existingColshape = this.findByID(id);
+    if (existingColshape) {
+      return existingColshape;
+    }
+
+    const ccmpColshape = ccmp.colshapes.getById(id);
+    if (!ccmpColshape) {
+      throw new Error(`CCMPColshapesManager.registerById(${id}): colshape not found.`);
+    }
+
+    return this._register(ccmpColshape);
+  }
+
+  public unregisterById(id: number): CCMPColshape {
+    return this.deleteById(id);
+  }
+
+  public findByID(id: number): CCMPColshape | null {
+    const colshape = this._colshapes.get(id) ?? null;
+    if (colshape && !colshape.isExists) {
+      this._colshapes.delete(id);
+    } else if (colshape) {
+      return colshape;
+    }
+
+    const ccmpColshape = ccmp.colshapes.getById(id);
+    if (!ccmpColshape) {
+      return null;
+    }
+
+    return this._register(ccmpColshape);
+  }
+
+  public getByID(id: number): CCMPColshape {
+    const colshape = this.findByID(id);
+    if (!colshape) {
+      throw new Error(`CCMPColshapesManager.getByID(${id}): colshape not found.`);
+    }
+    return colshape;
+  }
+
+  public findByRemoteID(remoteId: number): CCMPColshape | null {
+    return this.findByID(remoteId);
+  }
+
+  public getByRemoteID(remoteId: number): CCMPColshape {
+    const colshape = this.findByRemoteID(remoteId);
+    if (!colshape) {
+      throw new Error(`CCMPColshapesManager.getByRemoteID(${remoteId}): colshape not found.`);
+    }
+    return colshape;
+  }
+
+  public deleteById(id: number): CCMPColshape {
+    const colshape = this.getByID(id);
+    colshape.destroy();
+    return colshape;
+  }
+
+  public get iterator(): IWorldObjectsIterator<CCMPColshape> {
+    return this._iterator;
+  }
+
+  private _register(ccmpColshape: CcmpColshape): CCMPColshape {
+    const existingColshape = this._colshapes.get(ccmpColshape.id) ?? null;
+    if (existingColshape && existingColshape.isExists) {
+      return existingColshape;
+    }
+
+    const colshape = new CCMPColshape(ccmpColshape, (destroyedColshape) => {
+      this._colshapes.delete(destroyedColshape.id);
+    });
+    this._colshapes.set(colshape.id, colshape);
+    return colshape;
+  }
+
+  private _registerLifecycleEvents(): void {
+    ccmp.on("colshapeCreated", (ccmpColshape: CcmpColshape | null) => {
+      if (!ccmpColshape) return;
+      const colshape = this._register(ccmpColshape);
+      this._events.emitInternal(ClientInternalEventName.EntityCreated, colshape);
+    });
+
+    ccmp.on("colshapeDestroyed", (ccmpColshape: CcmpColshape | null) => {
+      if (!ccmpColshape) return;
+      const colshape = this._colshapes.get(ccmpColshape.id) ?? this._register(ccmpColshape);
+      this._events.emitInternal(ClientInternalEventName.EntityDestroyed, colshape);
+      this._colshapes.delete(colshape.id);
+    });
+
+    ccmp.on("colshapeStreamIn", (ccmpColshape: CcmpColshape | null) => {
+      if (!ccmpColshape) return;
+      const colshape = this._register(ccmpColshape);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamIn, colshape);
+    });
+
+    ccmp.on("colshapeStreamOut", (ccmpColshape: CcmpColshape | null) => {
+      if (!ccmpColshape) return;
+      const colshape = this._colshapes.get(ccmpColshape.id) ?? this._register(ccmpColshape);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamOut, colshape);
+    });
+  }
+
+  private *_filter(predicate: (colshape: CCMPColshape) => boolean): IterableIterator<CCMPColshape> {
+    for (const colshape of this._colshapes.values()) {
+      if (!colshape.isExists) {
+        this._colshapes.delete(colshape.id);
+        continue;
+      }
+
+      if (predicate(colshape)) {
+        yield colshape;
+      }
+    }
+  }
+
+  private _pruneDestroyed(): void {
+    for (const colshape of this._colshapes.values()) {
+      if (!colshape.isExists) {
+        this._colshapes.delete(colshape.id);
+      }
+    }
+  }
+}

--- a/src/client/entities/ccmp/marker/CCMPMarker.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarker.ts
@@ -39,6 +39,7 @@ export class CCMPMarker implements IMarker {
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ccmpMarker.destroy();
     this._onDestroy(this);
   }
 

--- a/src/client/entities/ccmp/marker/CCMPMarker.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarker.ts
@@ -20,7 +20,7 @@ export class CCMPMarker implements IMarker {
     return this._ccmpMarker.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpMarker.remoteId;
   }
 

--- a/src/client/entities/ccmp/marker/CCMPMarker.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarker.ts
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { BaseObjectType, type IMarkerType } from "@shared/entities";
+import { type IRGBA, RGBA, type IVector3D, Vector3D } from "@shared/common/utils";
+import { type Marker as CcmpMarker } from "@classic-mp/types/client";
+import { type IMarker } from "../../common/marker/IMarker";
+
+const notImplemented = (memberName: string): never => {
+  throw new Error(`CCMPMarker.${memberName}: not implemented`);
+};
+
+export class CCMPMarker implements IMarker {
+  private _destroyed = false;
+
+  public constructor(
+    private readonly _ccmpMarker: CcmpMarker,
+    private readonly _onDestroy: (marker: CCMPMarker) => void = () => {},
+  ) {}
+
+  public get id(): number {
+    return this._ccmpMarker.id;
+  }
+
+  public get remoteId(): number {
+    return this._ccmpMarker.remoteId;
+  }
+
+  public get type(): BaseObjectType {
+    return BaseObjectType.Marker;
+  }
+
+  public get isExists(): boolean {
+    return !this._destroyed && this._ccmpMarker.isExists;
+  }
+
+  public get handle(): number {
+    return 0;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._onDestroy(this);
+  }
+
+  public get position(): Vector3D {
+    const { x, y, z } = this._ccmpMarker.position;
+    return new Vector3D(x, y, z);
+  }
+
+  public get dimension(): number {
+    return this._ccmpMarker.dimension;
+  }
+
+  public setPosition(_value: IVector3D): void {
+    notImplemented("setPosition");
+  }
+
+  public setDimension(_value: number): void {
+    notImplemented("setDimension");
+  }
+
+  public setCoords(
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xAxis: boolean,
+    _yAxis: boolean,
+    _zAxis: boolean,
+    _clearArea: boolean,
+  ): void {
+    notImplemented("setCoords");
+  }
+
+  public get markerType(): IMarkerType {
+    return this._ccmpMarker.markerType as IMarkerType;
+  }
+
+  public get visible(): boolean {
+    return this._ccmpMarker.visible;
+  }
+
+  public get rotation(): Vector3D {
+    const { x, y, z } = this._ccmpMarker.rotation;
+    return new Vector3D(x, y, z);
+  }
+
+  public setVisible(_value: boolean): void {
+    notImplemented("setVisible");
+  }
+
+  public setRotation(_value: IVector3D): void {
+    notImplemented("setRotation");
+  }
+
+  public get scale(): number {
+    return this._ccmpMarker.scale;
+  }
+
+  public setScale(_value: number): void {
+    notImplemented("setScale");
+  }
+
+  public get color(): IRGBA {
+    const { r, g, b, a } = this._ccmpMarker.color;
+    return new RGBA(r, g, b, a);
+  }
+
+  public setColor(_value: IRGBA): void {
+    notImplemented("setColor");
+  }
+}

--- a/src/client/entities/ccmp/marker/CCMPMarker.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarker.ts
@@ -85,6 +85,43 @@ export class CCMPMarker implements IMarker {
     return new Vector3D(x, y, z);
   }
 
+  public getVariable(name: string): unknown | null {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Marker, remoteId, name);
+    return value === undefined ? null : value;
+  }
+
+  public getSyncedMeta(key: string): unknown | undefined {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Marker, remoteId, key);
+  }
+
+  public hasSyncedMeta(key: string): boolean {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Marker, remoteId, key);
+  }
+
+  public getSyncedMetaKeys(): readonly string[] {
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Marker, remoteId);
+  }
+
   public setVisible(_value: boolean): void {
     notImplemented("setVisible");
   }

--- a/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
@@ -1,0 +1,171 @@
+import { type Marker as CcmpMarker } from "@classic-mp/types/client";
+import { type CCMPEventsManager } from "@RockMod/client/net/ccmp/events/CCMPEventsManager";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
+import { type IMarkerCreateOptions, type IMarkersManager } from "../../common/marker/IMarkersManager";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { CCMPMarker } from "./CCMPMarker";
+
+export class CCMPMarkersManager implements IMarkersManager {
+  private readonly _markers = new Map<number, CCMPMarker>();
+
+  private readonly _iterator: IWorldObjectsIterator<CCMPMarker> = {
+    all: (): IterableIterator<CCMPMarker> => this._filter(() => true),
+    dimension: (value: number): IterableIterator<CCMPMarker> => this._filter((marker) => marker.dimension === value),
+    range2D: (center: Vector2D, range: number): IterableIterator<CCMPMarker> =>
+      this._filter((marker) => {
+        const position = marker.position;
+        const squaredDistance = (position.x - center.x) ** 2 + (position.y - center.y) ** 2;
+        return squaredDistance <= range * range;
+      }),
+    range3D: (center: Vector3D, range: number): IterableIterator<CCMPMarker> =>
+      this._filter((marker) => marker.position.isInRange(center, range)),
+  };
+
+  public constructor(private readonly _events: CCMPEventsManager) {
+    this._registerLifecycleEvents();
+    this.syncWithMpPool();
+  }
+
+  public create(options: IMarkerCreateOptions): CCMPMarker {
+    void options;
+    throw new Error(
+      "CCMPMarkersManager.create: client-side marker creation is not supported by CCMP. Use server-side ccmp.markers.create.",
+    );
+  }
+
+  public syncWithMpPool(): void {
+    this._pruneDestroyed();
+
+    for (const ccmpMarker of ccmp.markers.all) {
+      if (!this._markers.has(ccmpMarker.id)) {
+        this._register(ccmpMarker);
+      }
+    }
+  }
+
+  public registerById(id: number): CCMPMarker {
+    const existingMarker = this.findByID(id);
+    if (existingMarker) {
+      return existingMarker;
+    }
+
+    const ccmpMarker = ccmp.markers.getById(id);
+    if (!ccmpMarker) {
+      throw new Error(`CCMPMarkersManager.registerById(${id}): marker not found.`);
+    }
+
+    return this._register(ccmpMarker);
+  }
+
+  public unregisterById(id: number): CCMPMarker {
+    return this.deleteById(id);
+  }
+
+  public findByID(id: number): CCMPMarker | null {
+    const marker = this._markers.get(id) ?? null;
+    if (marker && !marker.isExists) {
+      this._markers.delete(id);
+    } else if (marker) {
+      return marker;
+    }
+
+    const ccmpMarker = ccmp.markers.getById(id);
+    if (!ccmpMarker) {
+      return null;
+    }
+
+    return this._register(ccmpMarker);
+  }
+
+  public getByID(id: number): CCMPMarker {
+    const marker = this.findByID(id);
+    if (!marker) {
+      throw new Error(`CCMPMarkersManager.getByID(${id}): marker not found.`);
+    }
+    return marker;
+  }
+
+  public findByRemoteID(remoteId: number): CCMPMarker | null {
+    return this.findByID(remoteId);
+  }
+
+  public getByRemoteID(remoteId: number): CCMPMarker {
+    const marker = this.findByRemoteID(remoteId);
+    if (!marker) {
+      throw new Error(`CCMPMarkersManager.getByRemoteID(${remoteId}): marker not found.`);
+    }
+    return marker;
+  }
+
+  public deleteById(id: number): CCMPMarker {
+    const marker = this.getByID(id);
+    marker.destroy();
+    return marker;
+  }
+
+  public get iterator(): IWorldObjectsIterator<CCMPMarker> {
+    return this._iterator;
+  }
+
+  private _register(ccmpMarker: CcmpMarker): CCMPMarker {
+    const existingMarker = this._markers.get(ccmpMarker.id) ?? null;
+    if (existingMarker && existingMarker.isExists) {
+      return existingMarker;
+    }
+
+    const marker = new CCMPMarker(ccmpMarker, (destroyedMarker) => {
+      this._markers.delete(destroyedMarker.id);
+    });
+    this._markers.set(marker.id, marker);
+    return marker;
+  }
+
+  private _registerLifecycleEvents(): void {
+    ccmp.on("markerCreated", (ccmpMarker: CcmpMarker | null) => {
+      if (!ccmpMarker) return;
+      const marker = this._register(ccmpMarker);
+      this._events.emitInternal(ClientInternalEventName.EntityCreated, marker);
+    });
+
+    ccmp.on("markerDestroyed", (ccmpMarker: CcmpMarker | null) => {
+      if (!ccmpMarker) return;
+      const marker = this._markers.get(ccmpMarker.id) ?? this._register(ccmpMarker);
+      this._events.emitInternal(ClientInternalEventName.EntityDestroyed, marker);
+      this._markers.delete(marker.id);
+    });
+
+    ccmp.on("markerStreamIn", (ccmpMarker: CcmpMarker | null) => {
+      if (!ccmpMarker) return;
+      const marker = this._register(ccmpMarker);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamIn, marker);
+    });
+
+    ccmp.on("markerStreamOut", (ccmpMarker: CcmpMarker | null) => {
+      if (!ccmpMarker) return;
+      const marker = this._markers.get(ccmpMarker.id) ?? this._register(ccmpMarker);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamOut, marker);
+    });
+  }
+
+  private *_filter(predicate: (marker: CCMPMarker) => boolean): IterableIterator<CCMPMarker> {
+    for (const marker of this._markers.values()) {
+      if (!marker.isExists) {
+        this._markers.delete(marker.id);
+        continue;
+      }
+
+      if (predicate(marker)) {
+        yield marker;
+      }
+    }
+  }
+
+  private _pruneDestroyed(): void {
+    for (const marker of this._markers.values()) {
+      if (!marker.isExists) {
+        this._markers.delete(marker.id);
+      }
+    }
+  }
+}

--- a/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
@@ -30,10 +30,19 @@ export class CCMPMarkersManager implements IMarkersManager {
   }
 
   public create(options: IMarkerCreateOptions): CCMPMarker {
-    void options;
-    throw new Error(
-      "CCMPMarkersManager.create: client-side marker creation is not supported by CCMP. Use server-side ccmp.markers.create.",
-    );
+    const { r, g, b, a } = options.color;
+    const ccmpMarker = ccmp.markers.create(options.type, options.position, {
+      dimension: options.dimension,
+      rotation: options.rotation,
+      scale: options.scale,
+      color: { r, g, b, a: a ?? 255 },
+    });
+
+    if (!ccmpMarker) {
+      throw new Error(`CCMPMarkersManager.create: ccmp.markers.create failed for marker type "${options.type}"`);
+    }
+
+    return this._register(ccmpMarker);
   }
 
   public syncWithMpPool(): void {

--- a/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
+++ b/src/client/entities/ccmp/marker/CCMPMarkersManager.ts
@@ -9,6 +9,8 @@ import { CCMPMarker } from "./CCMPMarker";
 export class CCMPMarkersManager implements IMarkersManager {
   private readonly _markers = new Map<number, CCMPMarker>();
 
+  private readonly _markersByRemoteId = new Map<number, CCMPMarker>();
+
   private readonly _iterator: IWorldObjectsIterator<CCMPMarker> = {
     all: (): IterableIterator<CCMPMarker> => this._filter(() => true),
     dimension: (value: number): IterableIterator<CCMPMarker> => this._filter((marker) => marker.dimension === value),
@@ -38,9 +40,7 @@ export class CCMPMarkersManager implements IMarkersManager {
     this._pruneDestroyed();
 
     for (const ccmpMarker of ccmp.markers.all) {
-      if (!this._markers.has(ccmpMarker.id)) {
-        this._register(ccmpMarker);
-      }
+      this._register(ccmpMarker);
     }
   }
 
@@ -65,7 +65,7 @@ export class CCMPMarkersManager implements IMarkersManager {
   public findByID(id: number): CCMPMarker | null {
     const marker = this._markers.get(id) ?? null;
     if (marker && !marker.isExists) {
-      this._markers.delete(id);
+      this._unregister(marker);
     } else if (marker) {
       return marker;
     }
@@ -87,7 +87,19 @@ export class CCMPMarkersManager implements IMarkersManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPMarker | null {
-    return this.findByID(remoteId);
+    const marker = this._markersByRemoteId.get(remoteId) ?? null;
+    if (marker && !marker.isExists) {
+      this._unregister(marker);
+    } else if (marker) {
+      return marker;
+    }
+
+    const ccmpMarker = ccmp.markers.getByRemoteId(remoteId);
+    if (!ccmpMarker) {
+      return null;
+    }
+
+    return this._register(ccmpMarker);
   }
 
   public getByRemoteID(remoteId: number): CCMPMarker {
@@ -109,16 +121,37 @@ export class CCMPMarkersManager implements IMarkersManager {
   }
 
   private _register(ccmpMarker: CcmpMarker): CCMPMarker {
-    const existingMarker = this._markers.get(ccmpMarker.id) ?? null;
+    const existingMarker = this._findRegistered(ccmpMarker);
     if (existingMarker && existingMarker.isExists) {
       return existingMarker;
     }
+    if (existingMarker) {
+      this._unregister(existingMarker);
+    }
 
     const marker = new CCMPMarker(ccmpMarker, (destroyedMarker) => {
-      this._markers.delete(destroyedMarker.id);
+      this._unregister(destroyedMarker);
     });
     this._markers.set(marker.id, marker);
+    if (marker.remoteId !== null) {
+      this._markersByRemoteId.set(marker.remoteId, marker);
+    }
     return marker;
+  }
+
+  private _unregister(marker: CCMPMarker): void {
+    this._markers.delete(marker.id);
+    if (marker.remoteId !== null) {
+      this._markersByRemoteId.delete(marker.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpMarker: CcmpMarker): CCMPMarker | null {
+    return (
+      (ccmpMarker.remoteId === null ? null : (this._markersByRemoteId.get(ccmpMarker.remoteId) ?? null)) ??
+      this._markers.get(ccmpMarker.id) ??
+      null
+    );
   }
 
   private _registerLifecycleEvents(): void {
@@ -130,9 +163,9 @@ export class CCMPMarkersManager implements IMarkersManager {
 
     ccmp.on("markerDestroyed", (ccmpMarker: CcmpMarker | null) => {
       if (!ccmpMarker) return;
-      const marker = this._markers.get(ccmpMarker.id) ?? this._register(ccmpMarker);
+      const marker = this._findRegistered(ccmpMarker) ?? this._register(ccmpMarker);
       this._events.emitInternal(ClientInternalEventName.EntityDestroyed, marker);
-      this._markers.delete(marker.id);
+      this._unregister(marker);
     });
 
     ccmp.on("markerStreamIn", (ccmpMarker: CcmpMarker | null) => {
@@ -143,7 +176,7 @@ export class CCMPMarkersManager implements IMarkersManager {
 
     ccmp.on("markerStreamOut", (ccmpMarker: CcmpMarker | null) => {
       if (!ccmpMarker) return;
-      const marker = this._markers.get(ccmpMarker.id) ?? this._register(ccmpMarker);
+      const marker = this._findRegistered(ccmpMarker) ?? this._register(ccmpMarker);
       this._events.emitInternal(ClientInternalEventName.EntityStreamOut, marker);
     });
   }
@@ -151,7 +184,7 @@ export class CCMPMarkersManager implements IMarkersManager {
   private *_filter(predicate: (marker: CCMPMarker) => boolean): IterableIterator<CCMPMarker> {
     for (const marker of this._markers.values()) {
       if (!marker.isExists) {
-        this._markers.delete(marker.id);
+        this._unregister(marker);
         continue;
       }
 
@@ -164,7 +197,7 @@ export class CCMPMarkersManager implements IMarkersManager {
   private _pruneDestroyed(): void {
     for (const marker of this._markers.values()) {
       if (!marker.isExists) {
-        this._markers.delete(marker.id);
+        this._unregister(marker);
       }
     }
   }

--- a/src/client/entities/ccmp/object/CCMPObject.ts
+++ b/src/client/entities/ccmp/object/CCMPObject.ts
@@ -21,7 +21,7 @@ export class CCMPObject implements IObject {
     return this._ccmpObject.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpObject.remoteId;
   }
 
@@ -168,20 +168,40 @@ export class CCMPObject implements IObject {
   }
 
   public getVariable(name: string): unknown | null {
-    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, name);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, remoteId, name);
     return value === undefined ? null : value;
   }
 
   public getSyncedMeta(key: string): unknown | undefined {
-    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, remoteId, key);
   }
 
   public hasSyncedMeta(key: string): boolean {
-    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, remoteId, key);
   }
 
   public getSyncedMetaKeys(): readonly string[] {
-    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Object, this.remoteId);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Object, remoteId);
   }
 
   public attachTo(

--- a/src/client/entities/ccmp/object/CCMPObject.ts
+++ b/src/client/entities/ccmp/object/CCMPObject.ts
@@ -53,8 +53,8 @@ export class CCMPObject implements IObject {
     return this._ccmpObject.dimension;
   }
 
-  public setPosition(_value: IVector3D): void {
-    notImplemented("setPosition");
+  public setPosition(value: IVector3D): void {
+    this.setCoords(value.x, value.y, value.z, false, false, false, false);
   }
 
   public setDimension(_value: number): void {
@@ -62,15 +62,17 @@ export class CCMPObject implements IObject {
   }
 
   public setCoords(
-    _xPos: number,
-    _yPos: number,
-    _zPos: number,
-    _xAxis: boolean,
-    _yAxis: boolean,
-    _zAxis: boolean,
-    _clearArea: boolean,
+    xPos: number,
+    yPos: number,
+    zPos: number,
+    xAxis: boolean,
+    yAxis: boolean,
+    zAxis: boolean,
+    clearArea: boolean,
   ): void {
-    notImplemented("setCoords");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityCoords(handle, xPos, yPos, zPos, xAxis, yAxis, zAxis, clearArea);
+    });
   }
 
   public get model(): number {
@@ -81,8 +83,10 @@ export class CCMPObject implements IObject {
     return this._ccmpObject.heading;
   }
 
-  public setHeading(_heading: number): void {
-    notImplemented("setHeading");
+  public setHeading(heading: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityHeading(handle, heading);
+    });
   }
 
   public setModel(_value: string): void {
@@ -99,36 +103,50 @@ export class CCMPObject implements IObject {
     return new Vector3D(-Math.sin(headingRad), Math.cos(headingRad), 0);
   }
 
-  public setRotation(_value: IVector3D): void {
-    notImplemented("setRotation");
+  public setRotation(value: IVector3D): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityRotation(handle, value.x, value.y, value.z, 2, true);
+    });
   }
 
-  public freezePosition(_freeze: boolean): void {
-    notImplemented("freezePosition");
+  public freezePosition(freeze: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.freezeEntityPosition(handle, freeze);
+    });
   }
 
-  public setCollision(_collision: boolean, _keepPhysics: boolean): void {
-    notImplemented("setCollision");
+  public setCollision(collision: boolean, keepPhysics: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityCollision(handle, collision, keepPhysics);
+    });
   }
 
-  public setInvincible(_invincible: boolean): void {
-    notImplemented("setInvincible");
+  public setInvincible(invincible: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityInvincible(handle, invincible, true);
+    });
   }
 
-  public setVisible(_visible: boolean): void {
-    notImplemented("setVisible");
+  public setVisible(visible: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityVisible(handle, visible, false);
+    });
   }
 
-  public setAlpha(_alpha: number): void {
-    notImplemented("setAlpha");
+  public setAlpha(alpha: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityAlpha(handle, alpha, false);
+    });
   }
 
   public get alpha(): number {
-    return this._ccmpObject.alpha;
+    return this._withHandle(this._ccmpObject.alpha, (handle) => ccmp.natives.entity.getEntityAlpha(handle));
   }
 
   public resetAlpha(): void {
-    notImplemented("resetAlpha");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.resetEntityAlpha(handle);
+    });
   }
 
   public getOffsetFromInWorldCoords(offsetX: number, offsetY: number, offsetZ: number): IVector3D {
@@ -167,52 +185,103 @@ export class CCMPObject implements IObject {
   }
 
   public attachTo(
-    _entity: Handle,
-    _boneIndex: number,
-    _xPos: number,
-    _yPos: number,
-    _zPos: number,
-    _xRot: number,
-    _yRot: number,
-    _zRot: number,
-    _useSoftPinning: boolean,
-    _collision: boolean,
-    _isPed: boolean,
-    _vertexIndex: number,
-    _fixedRot: boolean,
+    entity: Handle,
+    boneIndex: number,
+    xPos: number,
+    yPos: number,
+    zPos: number,
+    xRot: number,
+    yRot: number,
+    zRot: number,
+    useSoftPinning: boolean,
+    collision: boolean,
+    isPed: boolean,
+    vertexIndex: number,
+    fixedRot: boolean,
   ): void {
-    notImplemented("attachTo");
+    const targetHandle = this._normalizeHandle(entity);
+    if (!targetHandle) return;
+
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.attachEntityToEntity(
+        handle,
+        targetHandle,
+        boneIndex,
+        xPos,
+        yPos,
+        zPos,
+        xRot,
+        yRot,
+        zRot,
+        false,
+        useSoftPinning,
+        collision,
+        isPed,
+        vertexIndex,
+        fixedRot,
+        0,
+      );
+    });
   }
 
-  public isAttachedTo(_entity: number): boolean {
-    return notImplemented("isAttachedTo");
+  public isAttachedTo(entity: number): boolean {
+    const targetHandle = this._normalizeHandle(entity);
+    if (!targetHandle) return false;
+
+    return this._withHandle(false, (handle) => ccmp.natives.entity.isEntityAttachedToEntity(handle, targetHandle));
   }
 
   public attachToEntity(
-    _target: IBaseObject,
-    _boneIndex: number,
-    _offset: IVector3D,
-    _rotation: IVector3D,
-    _p9: boolean,
-    _useSoftPinning: boolean,
-    _collision: boolean,
-    _isPed: boolean,
-    _vertexIndex: number,
-    _fixedRot: boolean,
+    target: IBaseObject,
+    boneIndex: number,
+    offset: IVector3D,
+    rotation: IVector3D,
+    p9: boolean,
+    useSoftPinning: boolean,
+    collision: boolean,
+    isPed: boolean,
+    vertexIndex: number,
+    fixedRot: boolean,
   ): void {
-    notImplemented("attachToEntity");
+    const targetHandle = this._normalizeHandle(target.handle);
+    if (!targetHandle) return;
+
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.attachEntityToEntity(
+        handle,
+        targetHandle,
+        boneIndex,
+        offset.x,
+        offset.y,
+        offset.z,
+        rotation.x,
+        rotation.y,
+        rotation.z,
+        p9,
+        useSoftPinning,
+        collision,
+        isPed,
+        vertexIndex,
+        fixedRot,
+        0,
+      );
+    });
   }
 
-  public detach(_useDetachVelocity: boolean, _collision: boolean): void {
-    notImplemented("detach");
+  public detach(useDetachVelocity: boolean, collision: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.detachEntity(handle, useDetachVelocity, collision);
+    });
   }
 
   public getSpeed(): number {
     return this._withHandle(0, (handle) => ccmp.natives.entity.getEntitySpeed(handle));
   }
 
-  public isPlayingAnim(_dictionary: string, _name: string, _taskFlag: number): boolean {
-    return notImplemented("isPlayingAnim");
+  public isPlayingAnim(dictionary: string, name: string, taskFlag: number): boolean {
+    return this._withHandle(false, (handle) =>
+      ccmp.natives.entity.isEntityPlayingAnim(handle, dictionary, name, taskFlag),
+    );
   }
 
   private _withHandle<T>(fallback: T, callback: (handle: number) => T): T {
@@ -222,6 +291,20 @@ export class CCMPObject implements IObject {
     }
 
     return callback(handle);
+  }
+
+  private _withHandleVoid(callback: (handle: number) => void): void {
+    const handle = this.handle;
+    if (!handle) {
+      return;
+    }
+
+    callback(handle);
+  }
+
+  private _normalizeHandle(value: number): number {
+    const handle = Number(value);
+    return Number.isFinite(handle) && handle > 0 ? Math.trunc(handle) : 0;
   }
 
   private _getOffsetFromCachedTransform(offsetX: number, offsetY: number, offsetZ: number): Vector3D {

--- a/src/client/entities/ccmp/object/CCMPObject.ts
+++ b/src/client/entities/ccmp/object/CCMPObject.ts
@@ -41,6 +41,7 @@ export class CCMPObject implements IObject {
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ccmpObject.destroy();
     this._onDestroy(this);
   }
 

--- a/src/client/entities/ccmp/object/CCMPObject.ts
+++ b/src/client/entities/ccmp/object/CCMPObject.ts
@@ -1,0 +1,241 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { BaseObjectType } from "@shared/entities";
+import { type IVector3D, Vector3D } from "@shared/common/utils";
+import { type Object as CcmpObject } from "@classic-mp/types/client";
+import { type IBaseObject } from "../../common/baseObject/IBaseObject";
+import { type IObject } from "../../common/object/IObject";
+
+const notImplemented = (memberName: string): never => {
+  throw new Error(`CCMPObject.${memberName}: not implemented`);
+};
+
+export class CCMPObject implements IObject {
+  private _destroyed = false;
+
+  public constructor(
+    private readonly _ccmpObject: CcmpObject,
+    private readonly _onDestroy: (object: CCMPObject) => void = () => {},
+  ) {}
+
+  public get id(): number {
+    return this._ccmpObject.id;
+  }
+
+  public get remoteId(): number {
+    return this._ccmpObject.remoteId;
+  }
+
+  public get type(): BaseObjectType {
+    return BaseObjectType.Object;
+  }
+
+  public get isExists(): boolean {
+    return !this._destroyed && this._ccmpObject.isExists;
+  }
+
+  public get handle(): number {
+    const handle = Number(this._ccmpObject.handle);
+    return Number.isFinite(handle) && handle > 0 ? Math.trunc(handle) : 0;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._onDestroy(this);
+  }
+
+  public get position(): Vector3D {
+    const { x, y, z } = this._ccmpObject.position;
+    return new Vector3D(x, y, z);
+  }
+
+  public get dimension(): number {
+    return this._ccmpObject.dimension;
+  }
+
+  public setPosition(_value: IVector3D): void {
+    notImplemented("setPosition");
+  }
+
+  public setDimension(_value: number): void {
+    notImplemented("setDimension");
+  }
+
+  public setCoords(
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xAxis: boolean,
+    _yAxis: boolean,
+    _zAxis: boolean,
+    _clearArea: boolean,
+  ): void {
+    notImplemented("setCoords");
+  }
+
+  public get model(): number {
+    return this._ccmpObject.model;
+  }
+
+  public get heading(): number {
+    return this._ccmpObject.heading;
+  }
+
+  public setHeading(_heading: number): void {
+    notImplemented("setHeading");
+  }
+
+  public setModel(_value: string): void {
+    notImplemented("setModel");
+  }
+
+  public get rotation(): Vector3D {
+    const { x, y, z } = this._ccmpObject.rotation;
+    return new Vector3D(x, y, z);
+  }
+
+  public get forwardVector(): Vector3D {
+    const headingRad = (this.heading * Math.PI) / 180;
+    return new Vector3D(-Math.sin(headingRad), Math.cos(headingRad), 0);
+  }
+
+  public setRotation(_value: IVector3D): void {
+    notImplemented("setRotation");
+  }
+
+  public freezePosition(_freeze: boolean): void {
+    notImplemented("freezePosition");
+  }
+
+  public setCollision(_collision: boolean, _keepPhysics: boolean): void {
+    notImplemented("setCollision");
+  }
+
+  public setInvincible(_invincible: boolean): void {
+    notImplemented("setInvincible");
+  }
+
+  public setVisible(_visible: boolean): void {
+    notImplemented("setVisible");
+  }
+
+  public setAlpha(_alpha: number): void {
+    notImplemented("setAlpha");
+  }
+
+  public get alpha(): number {
+    return this._ccmpObject.alpha;
+  }
+
+  public resetAlpha(): void {
+    notImplemented("resetAlpha");
+  }
+
+  public getOffsetFromInWorldCoords(offsetX: number, offsetY: number, offsetZ: number): IVector3D {
+    return this._withHandle(this._getOffsetFromCachedTransform(offsetX, offsetY, offsetZ), (handle) => {
+      const { x, y, z } = ccmp.natives.entity.getOffsetFromEntityInWorldCoords(handle, offsetX, offsetY, offsetZ);
+      return new Vector3D(x, y, z);
+    });
+  }
+
+  public getBoneIndexByName(boneName: string): number {
+    return this._withHandle(-1, (handle) => ccmp.natives.entity.getEntityBoneIndexByName(handle, boneName));
+  }
+
+  public getWorldPositionOfBone(boneIndex: number): IVector3D {
+    return this._withHandle(this.position, (handle) => {
+      const { x, y, z } = ccmp.natives.entity.getWorldPositionOfEntityBone(handle, boneIndex);
+      return new Vector3D(x, y, z);
+    });
+  }
+
+  public getVariable(name: string): unknown | null {
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, name);
+    return value === undefined ? null : value;
+  }
+
+  public getSyncedMeta(key: string): unknown | undefined {
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, key);
+  }
+
+  public hasSyncedMeta(key: string): boolean {
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Object, this.remoteId, key);
+  }
+
+  public getSyncedMetaKeys(): readonly string[] {
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Object, this.remoteId);
+  }
+
+  public attachTo(
+    _entity: Handle,
+    _boneIndex: number,
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xRot: number,
+    _yRot: number,
+    _zRot: number,
+    _useSoftPinning: boolean,
+    _collision: boolean,
+    _isPed: boolean,
+    _vertexIndex: number,
+    _fixedRot: boolean,
+  ): void {
+    notImplemented("attachTo");
+  }
+
+  public isAttachedTo(_entity: number): boolean {
+    return notImplemented("isAttachedTo");
+  }
+
+  public attachToEntity(
+    _target: IBaseObject,
+    _boneIndex: number,
+    _offset: IVector3D,
+    _rotation: IVector3D,
+    _p9: boolean,
+    _useSoftPinning: boolean,
+    _collision: boolean,
+    _isPed: boolean,
+    _vertexIndex: number,
+    _fixedRot: boolean,
+  ): void {
+    notImplemented("attachToEntity");
+  }
+
+  public detach(_useDetachVelocity: boolean, _collision: boolean): void {
+    notImplemented("detach");
+  }
+
+  public getSpeed(): number {
+    return this._withHandle(0, (handle) => ccmp.natives.entity.getEntitySpeed(handle));
+  }
+
+  public isPlayingAnim(_dictionary: string, _name: string, _taskFlag: number): boolean {
+    return notImplemented("isPlayingAnim");
+  }
+
+  private _withHandle<T>(fallback: T, callback: (handle: number) => T): T {
+    const handle = this.handle;
+    if (!handle) {
+      return fallback;
+    }
+
+    return callback(handle);
+  }
+
+  private _getOffsetFromCachedTransform(offsetX: number, offsetY: number, offsetZ: number): Vector3D {
+    const position = this.position;
+    const headingRad = (this.heading * Math.PI) / 180;
+    const rightX = Math.cos(headingRad);
+    const rightY = Math.sin(headingRad);
+    const forwardX = -Math.sin(headingRad);
+    const forwardY = Math.cos(headingRad);
+
+    return new Vector3D(
+      position.x + rightX * offsetX + forwardX * offsetY,
+      position.y + rightY * offsetX + forwardY * offsetY,
+      position.z + offsetZ,
+    );
+  }
+}

--- a/src/client/entities/ccmp/object/CCMPObjectsManager.ts
+++ b/src/client/entities/ccmp/object/CCMPObjectsManager.ts
@@ -30,10 +30,16 @@ export class CCMPObjectsManager implements IObjectsManager {
   }
 
   public create(options: IObjectCreateOptions): CCMPObject {
-    void options;
-    throw new Error(
-      "CCMPObjectsManager.create: client-side object creation is not supported by CCMP. Use server-side ccmp.objects.create.",
-    );
+    const ccmpObject = ccmp.objects.create(options.model, options.position, options.rotation, {
+      dimension: options.dimension,
+      alpha: options.alpha,
+    });
+
+    if (!ccmpObject) {
+      throw new Error(`CCMPObjectsManager.create: ccmp.objects.create failed for model "${options.model}"`);
+    }
+
+    return this._register(ccmpObject);
   }
 
   public syncWithMpPool(): void {

--- a/src/client/entities/ccmp/object/CCMPObjectsManager.ts
+++ b/src/client/entities/ccmp/object/CCMPObjectsManager.ts
@@ -1,0 +1,171 @@
+import { type Object as CcmpObject } from "@classic-mp/types/client";
+import { type CCMPEventsManager } from "@RockMod/client/net/ccmp/events/CCMPEventsManager";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
+import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
+import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { CCMPObject } from "./CCMPObject";
+
+export class CCMPObjectsManager implements IObjectsManager {
+  private readonly _objects = new Map<number, CCMPObject>();
+
+  private readonly _iterator: IWorldObjectsIterator<CCMPObject> = {
+    all: (): IterableIterator<CCMPObject> => this._filter(() => true),
+    dimension: (value: number): IterableIterator<CCMPObject> => this._filter((object) => object.dimension === value),
+    range2D: (center: Vector2D, range: number): IterableIterator<CCMPObject> =>
+      this._filter((object) => {
+        const position = object.position;
+        const squaredDistance = (position.x - center.x) ** 2 + (position.y - center.y) ** 2;
+        return squaredDistance <= range * range;
+      }),
+    range3D: (center: Vector3D, range: number): IterableIterator<CCMPObject> =>
+      this._filter((object) => object.position.isInRange(center, range)),
+  };
+
+  public constructor(private readonly _events: CCMPEventsManager) {
+    this._registerLifecycleEvents();
+    this.syncWithMpPool();
+  }
+
+  public create(options: IObjectCreateOptions): CCMPObject {
+    void options;
+    throw new Error(
+      "CCMPObjectsManager.create: client-side object creation is not supported by CCMP. Use server-side ccmp.objects.create.",
+    );
+  }
+
+  public syncWithMpPool(): void {
+    this._pruneDestroyed();
+
+    for (const ccmpObject of ccmp.objects.all) {
+      if (!this._objects.has(ccmpObject.id)) {
+        this._register(ccmpObject);
+      }
+    }
+  }
+
+  public registerById(id: number): CCMPObject {
+    const existingObject = this.findByID(id);
+    if (existingObject) {
+      return existingObject;
+    }
+
+    const ccmpObject = ccmp.objects.getById(id);
+    if (!ccmpObject) {
+      throw new Error(`CCMPObjectsManager.registerById(${id}): object not found.`);
+    }
+
+    return this._register(ccmpObject);
+  }
+
+  public unregisterById(id: number): CCMPObject {
+    return this.deleteById(id);
+  }
+
+  public findByID(id: number): CCMPObject | null {
+    const object = this._objects.get(id) ?? null;
+    if (object && !object.isExists) {
+      this._objects.delete(id);
+    } else if (object) {
+      return object;
+    }
+
+    const ccmpObject = ccmp.objects.getById(id);
+    if (!ccmpObject) {
+      return null;
+    }
+
+    return this._register(ccmpObject);
+  }
+
+  public getByID(id: number): CCMPObject {
+    const object = this.findByID(id);
+    if (!object) {
+      throw new Error(`CCMPObjectsManager.getByID(${id}): object not found.`);
+    }
+    return object;
+  }
+
+  public findByRemoteID(remoteId: number): CCMPObject | null {
+    return this.findByID(remoteId);
+  }
+
+  public getByRemoteID(remoteId: number): CCMPObject {
+    const object = this.findByRemoteID(remoteId);
+    if (!object) {
+      throw new Error(`CCMPObjectsManager.getByRemoteID(${remoteId}): object not found.`);
+    }
+    return object;
+  }
+
+  public deleteById(id: number): CCMPObject {
+    const object = this.getByID(id);
+    object.destroy();
+    return object;
+  }
+
+  public get iterator(): IWorldObjectsIterator<CCMPObject> {
+    return this._iterator;
+  }
+
+  private _register(ccmpObject: CcmpObject): CCMPObject {
+    const existingObject = this._objects.get(ccmpObject.id) ?? null;
+    if (existingObject && existingObject.isExists) {
+      return existingObject;
+    }
+
+    const object = new CCMPObject(ccmpObject, (destroyedObject) => {
+      this._objects.delete(destroyedObject.id);
+    });
+    this._objects.set(object.id, object);
+    return object;
+  }
+
+  private _registerLifecycleEvents(): void {
+    ccmp.on("objectCreated", (ccmpObject: CcmpObject | null) => {
+      if (!ccmpObject) return;
+      const object = this._register(ccmpObject);
+      this._events.emitInternal(ClientInternalEventName.EntityCreated, object);
+    });
+
+    ccmp.on("objectDestroyed", (ccmpObject: CcmpObject | null) => {
+      if (!ccmpObject) return;
+      const object = this._objects.get(ccmpObject.id) ?? this._register(ccmpObject);
+      this._events.emitInternal(ClientInternalEventName.EntityDestroyed, object);
+      this._objects.delete(object.id);
+    });
+
+    ccmp.on("objectStreamIn", (ccmpObject: CcmpObject | null) => {
+      if (!ccmpObject) return;
+      const object = this._register(ccmpObject);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamIn, object);
+    });
+
+    ccmp.on("objectStreamOut", (ccmpObject: CcmpObject | null) => {
+      if (!ccmpObject) return;
+      const object = this._objects.get(ccmpObject.id) ?? this._register(ccmpObject);
+      this._events.emitInternal(ClientInternalEventName.EntityStreamOut, object);
+    });
+  }
+
+  private *_filter(predicate: (object: CCMPObject) => boolean): IterableIterator<CCMPObject> {
+    for (const object of this._objects.values()) {
+      if (!object.isExists) {
+        this._objects.delete(object.id);
+        continue;
+      }
+
+      if (predicate(object)) {
+        yield object;
+      }
+    }
+  }
+
+  private _pruneDestroyed(): void {
+    for (const object of this._objects.values()) {
+      if (!object.isExists) {
+        this._objects.delete(object.id);
+      }
+    }
+  }
+}

--- a/src/client/entities/ccmp/object/CCMPObjectsManager.ts
+++ b/src/client/entities/ccmp/object/CCMPObjectsManager.ts
@@ -9,6 +9,8 @@ import { CCMPObject } from "./CCMPObject";
 export class CCMPObjectsManager implements IObjectsManager {
   private readonly _objects = new Map<number, CCMPObject>();
 
+  private readonly _objectsByRemoteId = new Map<number, CCMPObject>();
+
   private readonly _iterator: IWorldObjectsIterator<CCMPObject> = {
     all: (): IterableIterator<CCMPObject> => this._filter(() => true),
     dimension: (value: number): IterableIterator<CCMPObject> => this._filter((object) => object.dimension === value),
@@ -38,9 +40,7 @@ export class CCMPObjectsManager implements IObjectsManager {
     this._pruneDestroyed();
 
     for (const ccmpObject of ccmp.objects.all) {
-      if (!this._objects.has(ccmpObject.id)) {
-        this._register(ccmpObject);
-      }
+      this._register(ccmpObject);
     }
   }
 
@@ -65,7 +65,7 @@ export class CCMPObjectsManager implements IObjectsManager {
   public findByID(id: number): CCMPObject | null {
     const object = this._objects.get(id) ?? null;
     if (object && !object.isExists) {
-      this._objects.delete(id);
+      this._unregister(object);
     } else if (object) {
       return object;
     }
@@ -87,7 +87,19 @@ export class CCMPObjectsManager implements IObjectsManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPObject | null {
-    return this.findByID(remoteId);
+    const object = this._objectsByRemoteId.get(remoteId) ?? null;
+    if (object && !object.isExists) {
+      this._unregister(object);
+    } else if (object) {
+      return object;
+    }
+
+    const ccmpObject = ccmp.objects.getByRemoteId(remoteId);
+    if (!ccmpObject) {
+      return null;
+    }
+
+    return this._register(ccmpObject);
   }
 
   public getByRemoteID(remoteId: number): CCMPObject {
@@ -109,16 +121,37 @@ export class CCMPObjectsManager implements IObjectsManager {
   }
 
   private _register(ccmpObject: CcmpObject): CCMPObject {
-    const existingObject = this._objects.get(ccmpObject.id) ?? null;
+    const existingObject = this._findRegistered(ccmpObject);
     if (existingObject && existingObject.isExists) {
       return existingObject;
     }
+    if (existingObject) {
+      this._unregister(existingObject);
+    }
 
     const object = new CCMPObject(ccmpObject, (destroyedObject) => {
-      this._objects.delete(destroyedObject.id);
+      this._unregister(destroyedObject);
     });
     this._objects.set(object.id, object);
+    if (object.remoteId !== null) {
+      this._objectsByRemoteId.set(object.remoteId, object);
+    }
     return object;
+  }
+
+  private _unregister(object: CCMPObject): void {
+    this._objects.delete(object.id);
+    if (object.remoteId !== null) {
+      this._objectsByRemoteId.delete(object.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpObject: CcmpObject): CCMPObject | null {
+    return (
+      (ccmpObject.remoteId === null ? null : (this._objectsByRemoteId.get(ccmpObject.remoteId) ?? null)) ??
+      this._objects.get(ccmpObject.id) ??
+      null
+    );
   }
 
   private _registerLifecycleEvents(): void {
@@ -130,9 +163,9 @@ export class CCMPObjectsManager implements IObjectsManager {
 
     ccmp.on("objectDestroyed", (ccmpObject: CcmpObject | null) => {
       if (!ccmpObject) return;
-      const object = this._objects.get(ccmpObject.id) ?? this._register(ccmpObject);
+      const object = this._findRegistered(ccmpObject) ?? this._register(ccmpObject);
       this._events.emitInternal(ClientInternalEventName.EntityDestroyed, object);
-      this._objects.delete(object.id);
+      this._unregister(object);
     });
 
     ccmp.on("objectStreamIn", (ccmpObject: CcmpObject | null) => {
@@ -143,7 +176,7 @@ export class CCMPObjectsManager implements IObjectsManager {
 
     ccmp.on("objectStreamOut", (ccmpObject: CcmpObject | null) => {
       if (!ccmpObject) return;
-      const object = this._objects.get(ccmpObject.id) ?? this._register(ccmpObject);
+      const object = this._findRegistered(ccmpObject) ?? this._register(ccmpObject);
       this._events.emitInternal(ClientInternalEventName.EntityStreamOut, object);
     });
   }
@@ -151,7 +184,7 @@ export class CCMPObjectsManager implements IObjectsManager {
   private *_filter(predicate: (object: CCMPObject) => boolean): IterableIterator<CCMPObject> {
     for (const object of this._objects.values()) {
       if (!object.isExists) {
-        this._objects.delete(object.id);
+        this._unregister(object);
         continue;
       }
 
@@ -164,7 +197,7 @@ export class CCMPObjectsManager implements IObjectsManager {
   private _pruneDestroyed(): void {
     for (const object of this._objects.values()) {
       if (!object.isExists) {
-        this._objects.delete(object.id);
+        this._unregister(object);
       }
     }
   }

--- a/src/client/entities/ccmp/ped/CCMPPed.ts
+++ b/src/client/entities/ccmp/ped/CCMPPed.ts
@@ -16,7 +16,7 @@ export class CCMPPed implements IPed {
     return this._ccmpPed.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpPed.remoteId;
   }
 

--- a/src/client/entities/ccmp/ped/CCMPPed.ts
+++ b/src/client/entities/ccmp/ped/CCMPPed.ts
@@ -144,22 +144,40 @@ export class CCMPPed implements IPed {
   }
 
   public getVariable(name: string): unknown | null {
-    void name;
-    return null;
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Ped, remoteId, name);
+    return value === undefined ? null : value;
   }
 
   public getSyncedMeta(key: string): unknown | undefined {
-    void key;
-    return undefined;
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Ped, remoteId, key);
   }
 
   public hasSyncedMeta(key: string): boolean {
-    void key;
-    return false;
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Ped, remoteId, key);
   }
 
   public getSyncedMetaKeys(): readonly string[] {
-    return [];
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Ped, remoteId);
   }
 
   public attachToEntity(

--- a/src/client/entities/ccmp/ped/CCMPPedsManager.ts
+++ b/src/client/entities/ccmp/ped/CCMPPedsManager.ts
@@ -9,6 +9,8 @@ import { CCMPPed } from "./CCMPPed";
 export class CCMPPedsManager implements IPedsManager {
   private readonly _peds = new Map<number, CCMPPed>();
 
+  private readonly _pedsByRemoteId = new Map<number, CCMPPed>();
+
   private readonly _iterator: IWorldObjectsIterator<CCMPPed> = {
     all: (): IterableIterator<CCMPPed> => this._filter(() => true),
     dimension: (value: number): IterableIterator<CCMPPed> => this._filter((ped) => ped.dimension === value),
@@ -42,9 +44,7 @@ export class CCMPPedsManager implements IPedsManager {
     this._pruneDestroyed();
 
     for (const ccmpPed of ccmp.peds.all) {
-      if (!this._peds.has(ccmpPed.id)) {
-        this._register(ccmpPed);
-      }
+      this._register(ccmpPed);
     }
   }
 
@@ -69,7 +69,7 @@ export class CCMPPedsManager implements IPedsManager {
   public findByID(id: number): CCMPPed | null {
     const ped = this._peds.get(id) ?? null;
     if (ped && !ped.isExists) {
-      this._peds.delete(id);
+      this._unregister(ped);
     } else if (ped) {
       return ped;
     }
@@ -91,7 +91,19 @@ export class CCMPPedsManager implements IPedsManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPPed | null {
-    return this.findByID(remoteId);
+    const ped = this._pedsByRemoteId.get(remoteId) ?? null;
+    if (ped && !ped.isExists) {
+      this._unregister(ped);
+    } else if (ped) {
+      return ped;
+    }
+
+    const ccmpPed = ccmp.peds.getByRemoteId(remoteId);
+    if (!ccmpPed) {
+      return null;
+    }
+
+    return this._register(ccmpPed);
   }
 
   public getByRemoteID(remoteId: number): CCMPPed {
@@ -115,7 +127,7 @@ export class CCMPPedsManager implements IPedsManager {
   private *_filter(predicate: (ped: CCMPPed) => boolean): IterableIterator<CCMPPed> {
     for (const ped of this._peds.values()) {
       if (!ped.isExists) {
-        this._peds.delete(ped.id);
+        this._unregister(ped);
         continue;
       }
 
@@ -126,16 +138,37 @@ export class CCMPPedsManager implements IPedsManager {
   }
 
   private _register(ccmpPed: CcmpPed): CCMPPed {
-    const existingPed = this._peds.get(ccmpPed.id) ?? null;
+    const existingPed = this._findRegistered(ccmpPed);
     if (existingPed && existingPed.isExists) {
       return existingPed;
     }
+    if (existingPed) {
+      this._unregister(existingPed);
+    }
 
     const ped = new CCMPPed(ccmpPed, (destroyedPed) => {
-      this._peds.delete(destroyedPed.id);
+      this._unregister(destroyedPed);
     });
     this._peds.set(ped.id, ped);
+    if (ped.remoteId !== null) {
+      this._pedsByRemoteId.set(ped.remoteId, ped);
+    }
     return ped;
+  }
+
+  private _unregister(ped: CCMPPed): void {
+    this._peds.delete(ped.id);
+    if (ped.remoteId !== null) {
+      this._pedsByRemoteId.delete(ped.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpPed: CcmpPed): CCMPPed | null {
+    return (
+      (ccmpPed.remoteId === null ? null : (this._pedsByRemoteId.get(ccmpPed.remoteId) ?? null)) ??
+      this._peds.get(ccmpPed.id) ??
+      null
+    );
   }
 
   private _registerStreamEvents(): void {
@@ -148,9 +181,9 @@ export class CCMPPedsManager implements IPedsManager {
 
     ccmp.on("pedDestroyed", (ccmpPed: CcmpPed | null) => {
       if (ccmpPed) {
-        const ped = this._peds.get(ccmpPed.id) ?? this._register(ccmpPed);
+        const ped = this._findRegistered(ccmpPed) ?? this._register(ccmpPed);
         this._events.emitInternal(ClientInternalEventName.EntityDestroyed, ped);
-        this._peds.delete(ped.id);
+        this._unregister(ped);
       }
     });
 
@@ -163,7 +196,7 @@ export class CCMPPedsManager implements IPedsManager {
 
     ccmp.on("pedStreamOut", (ccmpPed: CcmpPed | null) => {
       if (ccmpPed) {
-        const ped = this._peds.get(ccmpPed.id) ?? this._register(ccmpPed);
+        const ped = this._findRegistered(ccmpPed) ?? this._register(ccmpPed);
         if (ped) {
           this._events.emitInternal(ClientInternalEventName.EntityStreamOut, ped);
         }
@@ -174,7 +207,7 @@ export class CCMPPedsManager implements IPedsManager {
   private _pruneDestroyed(): void {
     for (const ped of this._peds.values()) {
       if (!ped.isExists) {
-        this._peds.delete(ped.id);
+        this._unregister(ped);
       }
     }
   }

--- a/src/client/entities/ccmp/ped/CCMPPedsManager.ts
+++ b/src/client/entities/ccmp/ped/CCMPPedsManager.ts
@@ -139,6 +139,21 @@ export class CCMPPedsManager implements IPedsManager {
   }
 
   private _registerStreamEvents(): void {
+    ccmp.on("pedCreated", (ccmpPed: CcmpPed | null) => {
+      if (ccmpPed) {
+        const ped = this._register(ccmpPed);
+        this._events.emitInternal(ClientInternalEventName.EntityCreated, ped);
+      }
+    });
+
+    ccmp.on("pedDestroyed", (ccmpPed: CcmpPed | null) => {
+      if (ccmpPed) {
+        const ped = this._peds.get(ccmpPed.id) ?? this._register(ccmpPed);
+        this._events.emitInternal(ClientInternalEventName.EntityDestroyed, ped);
+        this._peds.delete(ped.id);
+      }
+    });
+
     ccmp.on("pedStreamIn", (ccmpPed: CcmpPed | null) => {
       if (ccmpPed) {
         const ped = this._register(ccmpPed);
@@ -148,11 +163,10 @@ export class CCMPPedsManager implements IPedsManager {
 
     ccmp.on("pedStreamOut", (ccmpPed: CcmpPed | null) => {
       if (ccmpPed) {
-        const ped = this._peds.get(ccmpPed.id) ?? null;
+        const ped = this._peds.get(ccmpPed.id) ?? this._register(ccmpPed);
         if (ped) {
           this._events.emitInternal(ClientInternalEventName.EntityStreamOut, ped);
         }
-        this._peds.delete(ccmpPed.id);
       }
     });
   }

--- a/src/client/entities/ccmp/ped/CCMPPedsManager.ts
+++ b/src/client/entities/ccmp/ped/CCMPPedsManager.ts
@@ -91,7 +91,7 @@ export class CCMPPedsManager implements IPedsManager {
   }
 
   public findByRemoteID(remoteId: number): CCMPPed | null {
-    return remoteId === 0 ? null : this.findByID(remoteId);
+    return this.findByID(remoteId);
   }
 
   public getByRemoteID(remoteId: number): CCMPPed {

--- a/src/client/entities/ccmp/ped/CCMPPedsManager.ts
+++ b/src/client/entities/ccmp/ped/CCMPPedsManager.ts
@@ -1,4 +1,6 @@
 import { type Ped as CcmpPed } from "@classic-mp/types/client";
+import { type CCMPEventsManager } from "@RockMod/client/net/ccmp/events/CCMPEventsManager";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
 import { type IPedCreateOptions, type IPedsManager } from "../../common/ped/IPedsManager";
 import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
 import { type Vector2D, type Vector3D } from "@shared/common/utils";
@@ -19,6 +21,11 @@ export class CCMPPedsManager implements IPedsManager {
     range3D: (center: Vector3D, range: number): IterableIterator<CCMPPed> =>
       this._filter((ped) => ped.position.isInRange(center, range)),
   };
+
+  public constructor(private readonly _events: CCMPEventsManager) {
+    this._registerStreamEvents();
+    this.syncWithMpPool();
+  }
 
   public create(options: IPedCreateOptions): CCMPPed {
     const { model, position, rotation, dimension } = options;
@@ -63,9 +70,16 @@ export class CCMPPedsManager implements IPedsManager {
     const ped = this._peds.get(id) ?? null;
     if (ped && !ped.isExists) {
       this._peds.delete(id);
+    } else if (ped) {
+      return ped;
+    }
+
+    const ccmpPed = ccmp.peds.getById(id);
+    if (!ccmpPed) {
       return null;
     }
-    return ped;
+
+    return this._register(ccmpPed);
   }
 
   public getByID(id: number): CCMPPed {
@@ -112,11 +126,35 @@ export class CCMPPedsManager implements IPedsManager {
   }
 
   private _register(ccmpPed: CcmpPed): CCMPPed {
+    const existingPed = this._peds.get(ccmpPed.id) ?? null;
+    if (existingPed && existingPed.isExists) {
+      return existingPed;
+    }
+
     const ped = new CCMPPed(ccmpPed, (destroyedPed) => {
       this._peds.delete(destroyedPed.id);
     });
     this._peds.set(ped.id, ped);
     return ped;
+  }
+
+  private _registerStreamEvents(): void {
+    ccmp.on("pedStreamIn", (ccmpPed: CcmpPed | null) => {
+      if (ccmpPed) {
+        const ped = this._register(ccmpPed);
+        this._events.emitInternal(ClientInternalEventName.EntityStreamIn, ped);
+      }
+    });
+
+    ccmp.on("pedStreamOut", (ccmpPed: CcmpPed | null) => {
+      if (ccmpPed) {
+        const ped = this._peds.get(ccmpPed.id) ?? null;
+        if (ped) {
+          this._events.emitInternal(ClientInternalEventName.EntityStreamOut, ped);
+        }
+        this._peds.delete(ccmpPed.id);
+      }
+    });
   }
 
   private _pruneDestroyed(): void {

--- a/src/client/entities/ccmp/player/CCMPPlayer.ts
+++ b/src/client/entities/ccmp/player/CCMPPlayer.ts
@@ -410,22 +410,28 @@ export class CCMPPlayer implements IPlayer {
   }
 
   public taskEnterVehicle(
-    _vehicleHandle: number,
-    _timeout: number,
-    _seat: number,
-    _speed: number,
-    _flag: number,
+    vehicleHandle: number,
+    timeout: number,
+    seat: number,
+    speed: number,
+    flag: number,
     _p6: number,
   ): void {
-    this._warnOnce("taskEnterVehicle");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.task.taskEnterVehicle(handle, vehicleHandle, timeout, seat, speed, flag, "");
+    });
   }
 
   public clearTasks(): void {
-    this._warnOnce("clearTasks");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.task.clearPedTasks(handle);
+    });
   }
 
   public clearTasksImmediately(): void {
-    this._warnOnce("clearTasksImmediately");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.task.clearPedTasksImmediately(handle);
+    });
   }
 
   public taskPlayAnim(

--- a/src/client/entities/ccmp/player/CCMPPlayersManager.ts
+++ b/src/client/entities/ccmp/player/CCMPPlayersManager.ts
@@ -20,9 +20,10 @@ interface ICCMPNativePlayer {
  *
  * ### Хранилище
  *
- * `Map<id, CCMPPlayer>`. У CCMP нет отдельных `id`/`remoteId` как в RageMP:
- * один числовой `id` приходит от сервера, и он же используется везде.
- * `findByID`/`findByRemoteID`/`findByRemoteId` маппятся на один lookup.
+ * `Map<id, CCMPPlayer>`. For CCMP players only, `id` and `remoteId` still
+ * mean the same server/network id. Non-player CCMP wrappers have a separate
+ * client-local `id` and nullable server `remoteId`.
+ * `findByID`/`findByRemoteID`/`findByRemoteId` map to one lookup for players.
  *
  * ### Жизненный цикл local player'а
  *
@@ -71,18 +72,33 @@ export class CCMPPlayersManager implements IPlayersManager {
       [ClientInternalEventName.PlayerReady]: (player: IPlayer): void => {
         // Если кто-то ещё эмитнул rm::playerReady (например, cooperation
         // fallback в будущем) — синхронизируем своё состояние.
-        this._ensurePlayer(player.remoteId, player.name, /* isLocal */ true);
+        const remoteId = player.remoteId;
+        if (remoteId === null) {
+          return;
+        }
+
+        this._ensurePlayer(remoteId, player.name, /* isLocal */ true);
       },
 
       [ClientInternalEventName.PlayerConnected]: (player: IPlayer): void => {
-        this._ensurePlayer(player.remoteId, player.name, /* isLocal */ false);
+        const remoteId = player.remoteId;
+        if (remoteId === null) {
+          return;
+        }
+
+        this._ensurePlayer(remoteId, player.name, /* isLocal */ false);
       },
 
       [ClientInternalEventName.PlayerDisconnected]: (player: IPlayer): void => {
-        const existing = this._players.get(player.remoteId);
+        const remoteId = player.remoteId;
+        if (remoteId === null) {
+          return;
+        }
+
+        const existing = this._players.get(remoteId);
         if (existing) {
           existing.markRemoved();
-          this._players.delete(player.remoteId);
+          this._players.delete(remoteId);
         }
       },
     });

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -155,8 +155,11 @@ export class CCMPVehicle implements IVehicle {
     });
   }
 
-  public getOffsetFromInWorldCoords(_offsetX: number, _offsetY: number, _offsetZ: number): IVector3D {
-    return notImplemented("getOffsetFromInWorldCoords");
+  public getOffsetFromInWorldCoords(offsetX: number, offsetY: number, offsetZ: number): IVector3D {
+    return this._withHandle(this._getOffsetFromCachedTransform(offsetX, offsetY, offsetZ), (handle) => {
+      const { x, y, z } = ccmp.natives.entity.getOffsetFromEntityInWorldCoords(handle, offsetX, offsetY, offsetZ);
+      return new Vector3D(x, y, z);
+    });
   }
 
   public getBoneIndexByName(boneName: string): number {
@@ -446,5 +449,20 @@ export class CCMPVehicle implements IVehicle {
     } catch {
       return true;
     }
+  }
+
+  private _getOffsetFromCachedTransform(offsetX: number, offsetY: number, offsetZ: number): Vector3D {
+    const position = this.position;
+    const headingRad = (this.heading * Math.PI) / 180;
+    const rightX = Math.cos(headingRad);
+    const rightY = Math.sin(headingRad);
+    const forwardX = -Math.sin(headingRad);
+    const forwardY = Math.cos(headingRad);
+
+    return new Vector3D(
+      position.x + rightX * offsetX + forwardX * offsetY,
+      position.y + rightY * offsetX + forwardY * offsetY,
+      position.z + offsetZ,
+    );
   }
 }

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -18,6 +18,7 @@ export interface ICCMPNativeVehicle {
   readonly heading: number;
   readonly numberPlateText: string;
   readonly numberPlate: string;
+  destroy(): boolean;
 }
 
 const notImplemented = (memberName: string): never => {
@@ -68,6 +69,7 @@ export class CCMPVehicle implements IVehicle {
   public destroy(): void {
     if (this._destroyed) return;
     this._destroyed = true;
+    this._ccmpVehicle.destroy();
     this._onDestroy(this);
   }
 

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -24,6 +24,13 @@ const notImplemented = (memberName: string): never => {
   throw new Error(`CCMPVehicle.${memberName}: not implemented`);
 };
 
+type CCMPVehicleNatives = typeof ccmp.natives.vehicle & {
+  setVehicleDashboardColor?: (vehicle: number, colorIndex: number) => void;
+  setVehicleDashboardColour?: (vehicle: number, colorIndex: number) => void;
+  setVehicleInteriorColor?: (vehicle: number, colorIndex: number) => void;
+  setVehicleInteriorColour?: (vehicle: number, colorIndex: number) => void;
+};
+
 export class CCMPVehicle implements IVehicle {
   private _destroyed = false;
 
@@ -289,56 +296,75 @@ export class CCMPVehicle implements IVehicle {
     notImplemented("setIsLocked");
   }
 
-  public setCustomPrimaryColour(_color: IRGB): void {
-    notImplemented("setCustomPrimaryColour");
+  public setCustomPrimaryColour(color: IRGB): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleCustomPrimaryColour(handle, color.r, color.g, color.b);
+    });
   }
 
-  public setCustomSecondaryColour(_color: IRGB): void {
-    notImplemented("setCustomSecondaryColour");
+  public setCustomSecondaryColour(color: IRGB): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleCustomSecondaryColour(handle, color.r, color.g, color.b);
+    });
   }
 
   public get customPrimaryColour(): IRGB {
-    return notImplemented("customPrimaryColour");
+    return this._withHandle({ r: 0, g: 0, b: 0 }, (handle) =>
+      ccmp.natives.vehicle.getVehicleCustomPrimaryColour(handle),
+    );
   }
 
   public get customSecondaryColour(): IRGB {
-    return notImplemented("customSecondaryColour");
+    return this._withHandle({ r: 0, g: 0, b: 0 }, (handle) =>
+      ccmp.natives.vehicle.getVehicleCustomSecondaryColour(handle),
+    );
   }
 
-  public setMod(_modType: number, _modIndex: number): void {
-    notImplemented("setMod");
+  public setMod(modType: number, modIndex: number): void {
+    this._withHandleVoid((handle) => {
+      this._setModKit(handle);
+      ccmp.natives.vehicle.setVehicleMod(handle, modType, modIndex, false);
+    });
   }
 
-  public getMod(_modType: number): number {
-    return notImplemented("getMod");
+  public getMod(modType: number): number {
+    return this._withHandle(-1, (handle) => ccmp.natives.vehicle.getVehicleMod(handle, modType));
   }
 
-  public getNumMods(_modType: number): number {
-    return notImplemented("getNumMods");
+  public getNumMods(modType: number): number {
+    return this._withHandle(0, (handle) => ccmp.natives.vehicle.getNumVehicleMods(handle, modType));
   }
 
-  public setNeonLightEnabled(_index: number, _toggle: boolean): void {
-    notImplemented("setNeonLightEnabled");
+  public setNeonLightEnabled(index: number, toggle: boolean): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleNeonEnabled(handle, index, toggle);
+    });
   }
 
-  public setNeonLightsColour(_color: IRGB): void {
-    notImplemented("setNeonLightsColour");
+  public setNeonLightsColour(color: IRGB): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleNeonColour(handle, color.r, color.g, color.b);
+    });
   }
 
-  public setWindowTint(_tintType: number): void {
-    notImplemented("setWindowTint");
+  public setWindowTint(tintType: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleWindowTint(handle, tintType);
+    });
   }
 
   public get windowTint(): number {
-    return notImplemented("windowTint");
+    return this._withHandle(0, (handle) => ccmp.natives.vehicle.getVehicleWindowTint(handle));
   }
 
-  public setWheelType(_wheelType: number): void {
-    notImplemented("setWheelType");
+  public setWheelType(wheelType: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleWheelType(handle, wheelType);
+    });
   }
 
   public get wheelType(): number {
-    return notImplemented("wheelType");
+    return this._withHandle(0, (handle) => ccmp.natives.vehicle.getVehicleWheelType(handle));
   }
 
   public setNumberPlateTextIndex(_index: number): void {
@@ -381,32 +407,51 @@ export class CCMPVehicle implements IVehicle {
     notImplemented("setCheatPowerIncrease");
   }
 
-  public toggleMod(_modType: number, _toggle: boolean): void {
-    notImplemented("toggleMod");
+  public toggleMod(modType: number, toggle: boolean): void {
+    this._withHandleVoid((handle) => {
+      this._setModKit(handle);
+      ccmp.natives.vehicle.toggleVehicleMod(handle, modType, toggle);
+    });
   }
 
-  public setTyreSmokeColor(_r: number, _g: number, _b: number): void {
-    notImplemented("setTyreSmokeColor");
+  public setTyreSmokeColor(r: number, g: number, b: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleTyreSmokeColor(handle, r, g, b);
+    });
   }
 
-  public setModColor1(_paintType: number, _color: number, _p3: number): void {
-    notImplemented("setModColor1");
+  public setModColor1(paintType: number, color: number, p3: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleModColor1(handle, paintType, color, p3);
+    });
   }
 
   public setExtraColours(_pearlescentColor: number, _wheelColor: number): void {
     notImplemented("setExtraColours");
   }
 
-  public setHeadlightColor(_colorIndex: number): void {
-    notImplemented("setHeadlightColor");
+  public setHeadlightColor(colorIndex: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.vehicle.setVehicleXenonLightColorIndex(handle, colorIndex);
+    });
   }
 
-  public setDashboardColor(_colorIndex: number): void {
-    notImplemented("setDashboardColor");
+  public setDashboardColor(colorIndex: number): void {
+    this._withHandleVoid((handle) => {
+      const vehicleNatives = ccmp.natives.vehicle as CCMPVehicleNatives;
+      const setDashboardColor = vehicleNatives.setVehicleDashboardColor ?? vehicleNatives.setVehicleDashboardColour;
+      if (!setDashboardColor) return;
+      setDashboardColor(handle, colorIndex);
+    });
   }
 
-  public setInteriorColor(_colorIndex: number): void {
-    notImplemented("setInteriorColor");
+  public setInteriorColor(colorIndex: number): void {
+    this._withHandleVoid((handle) => {
+      const vehicleNatives = ccmp.natives.vehicle as CCMPVehicleNatives;
+      const setInteriorColor = vehicleNatives.setVehicleInteriorColor ?? vehicleNatives.setVehicleInteriorColour;
+      if (!setInteriorColor) return;
+      setInteriorColor(handle, colorIndex);
+    });
   }
 
   public getMaxBraking(): number {
@@ -441,6 +486,10 @@ export class CCMPVehicle implements IVehicle {
     }
 
     callback(handle);
+  }
+
+  private _setModKit(handle: number): void {
+    ccmp.natives.vehicle.setVehicleModKit(handle, 0);
   }
 
   private _getRemoteVehicleExists(): boolean {

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -6,7 +6,7 @@ import { type ILightState, type IVehicle } from "../../common/vehicle/IVehicle";
 
 export interface ICCMPNativeVehicle {
   readonly id: number;
-  readonly remoteId: number;
+  readonly remoteId: number | null;
   readonly isRemote: boolean;
   readonly handle: number;
   readonly model: number;
@@ -43,7 +43,7 @@ export class CCMPVehicle implements IVehicle {
     return this._ccmpVehicle.id;
   }
 
-  public get remoteId(): number {
+  public get remoteId(): number | null {
     return this._ccmpVehicle.remoteId;
   }
 
@@ -181,20 +181,40 @@ export class CCMPVehicle implements IVehicle {
   }
 
   public getVariable(name: string): unknown | null {
-    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, name);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return null;
+    }
+
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, remoteId, name);
     return value === undefined ? null : value;
   }
 
   public getSyncedMeta(key: string): unknown | undefined {
-    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return undefined;
+    }
+
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, remoteId, key);
   }
 
   public hasSyncedMeta(key: string): boolean {
-    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, key);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return false;
+    }
+
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, remoteId, key);
   }
 
   public getSyncedMetaKeys(): readonly string[] {
-    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId);
+    const remoteId = this.remoteId;
+    if (remoteId === null) {
+      return [];
+    }
+
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Vehicle, remoteId);
   }
 
   public attachToEntity(

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -45,11 +45,17 @@ export class CCMPVehicle implements IVehicle {
   }
 
   public get isExists(): boolean {
+    if (this._destroyed) return false;
+    if (this._ccmpVehicle.isRemote) {
+      return this._getRemoteVehicleExists();
+    }
+
     return !this._destroyed && (this._ccmpVehicle.isExists ?? this._ccmpVehicle.isAlive);
   }
 
   public get handle(): number {
-    return this._ccmpVehicle.handle;
+    const handle = Number(this._ccmpVehicle.handle);
+    return Number.isFinite(handle) && handle > 0 ? Math.trunc(handle) : 0;
   }
 
   public destroy(): void {
@@ -133,28 +139,35 @@ export class CCMPVehicle implements IVehicle {
     notImplemented("setVisible");
   }
 
-  public setAlpha(_alpha: number): void {
-    notImplemented("setAlpha");
+  public setAlpha(alpha: number): void {
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.setEntityAlpha(handle, alpha, false);
+    });
   }
 
   public get alpha(): number {
-    return notImplemented("alpha");
+    return this._withHandle(255, (handle) => ccmp.natives.entity.getEntityAlpha(handle));
   }
 
   public resetAlpha(): void {
-    notImplemented("resetAlpha");
+    this._withHandleVoid((handle) => {
+      ccmp.natives.entity.resetEntityAlpha(handle);
+    });
   }
 
   public getOffsetFromInWorldCoords(_offsetX: number, _offsetY: number, _offsetZ: number): IVector3D {
     return notImplemented("getOffsetFromInWorldCoords");
   }
 
-  public getBoneIndexByName(_boneName: string): number {
-    return notImplemented("getBoneIndexByName");
+  public getBoneIndexByName(boneName: string): number {
+    return this._withHandle(-1, (handle) => ccmp.natives.entity.getEntityBoneIndexByName(handle, boneName));
   }
 
-  public getWorldPositionOfBone(_boneIndex: number): IVector3D {
-    return notImplemented("getWorldPositionOfBone");
+  public getWorldPositionOfBone(boneIndex: number): IVector3D {
+    return this._withHandle(this.position, (handle) => {
+      const { x, y, z } = ccmp.natives.entity.getWorldPositionOfEntityBone(handle, boneIndex);
+      return new Vector3D(x, y, z);
+    });
   }
 
   public getVariable(name: string): unknown | null {
@@ -407,5 +420,31 @@ export class CCMPVehicle implements IVehicle {
 
   public getModelMaxSpeed(): number {
     return notImplemented("getModelMaxSpeed");
+  }
+
+  private _withHandle<T>(fallback: T, callback: (handle: number) => T): T {
+    const handle = this.handle;
+    if (!handle) {
+      return fallback;
+    }
+
+    return callback(handle);
+  }
+
+  private _withHandleVoid(callback: (handle: number) => void): void {
+    const handle = this.handle;
+    if (!handle) {
+      return;
+    }
+
+    callback(handle);
+  }
+
+  private _getRemoteVehicleExists(): boolean {
+    try {
+      return this._ccmpVehicle.isExists ?? true;
+    } catch {
+      return true;
+    }
   }
 }

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -278,8 +278,8 @@ export class CCMPVehicle implements IVehicle {
     notImplemented("explode");
   }
 
-  public getPedInSeat(_seat: number): number {
-    return notImplemented("getPedInSeat");
+  public getPedInSeat(seat: number): number {
+    return this._withHandle(0, (handle) => ccmp.natives.vehicle.getPedInVehicleSeat(handle, seat, false));
   }
 
   public setUndriveable(_toggle: boolean): void {

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -1,0 +1,411 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { BaseObjectType } from "@shared/entities";
+import { type IRGB, type IVector3D, Vector3D } from "@shared/common/utils";
+import { type IBaseObject } from "../../common/baseObject/IBaseObject";
+import { type ILightState, type IVehicle } from "../../common/vehicle/IVehicle";
+
+export interface ICCMPNativeVehicle {
+  readonly id: number;
+  readonly remoteId: number;
+  readonly isRemote: boolean;
+  readonly handle: number;
+  readonly model: number;
+  readonly dimension: number;
+  readonly isAlive: boolean;
+  readonly isExists?: boolean;
+  readonly position: IVector3D;
+  readonly rotation: IVector3D;
+  readonly heading: number;
+  readonly numberPlateText: string;
+  readonly numberPlate: string;
+}
+
+const notImplemented = (memberName: string): never => {
+  throw new Error(`CCMPVehicle.${memberName}: not implemented`);
+};
+
+export class CCMPVehicle implements IVehicle {
+  private _destroyed = false;
+
+  public constructor(
+    private readonly _ccmpVehicle: ICCMPNativeVehicle,
+    private readonly _onDestroy: (vehicle: CCMPVehicle) => void = () => {},
+  ) {}
+
+  public get id(): number {
+    return this._ccmpVehicle.id;
+  }
+
+  public get remoteId(): number {
+    return this._ccmpVehicle.remoteId;
+  }
+
+  public get type(): BaseObjectType {
+    return BaseObjectType.Vehicle;
+  }
+
+  public get isExists(): boolean {
+    return !this._destroyed && (this._ccmpVehicle.isExists ?? this._ccmpVehicle.isAlive);
+  }
+
+  public get handle(): number {
+    return this._ccmpVehicle.handle;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._onDestroy(this);
+  }
+
+  public get position(): Vector3D {
+    const { x, y, z } = this._ccmpVehicle.position;
+    return new Vector3D(x, y, z);
+  }
+
+  public get dimension(): number {
+    return this._ccmpVehicle.dimension;
+  }
+
+  public setPosition(_value: IVector3D): void {
+    notImplemented("setPosition");
+  }
+
+  public setDimension(_value: number): void {
+    notImplemented("setDimension");
+  }
+
+  public setCoords(
+    _xPos: number,
+    _yPos: number,
+    _zPos: number,
+    _xAxis: boolean,
+    _yAxis: boolean,
+    _zAxis: boolean,
+    _clearArea: boolean,
+  ): void {
+    notImplemented("setCoords");
+  }
+
+  public get model(): number {
+    return this._ccmpVehicle.model;
+  }
+
+  public get heading(): number {
+    return this._ccmpVehicle.heading;
+  }
+
+  public setHeading(_heading: number): void {
+    notImplemented("setHeading");
+  }
+
+  public setModel(_value: string): void {
+    notImplemented("setModel");
+  }
+
+  public get rotation(): Vector3D {
+    const { x, y, z } = this._ccmpVehicle.rotation;
+    return new Vector3D(x, y, z);
+  }
+
+  public get forwardVector(): Vector3D {
+    const headingRad = (this.heading * Math.PI) / 180;
+    return new Vector3D(-Math.sin(headingRad), Math.cos(headingRad), 0);
+  }
+
+  public setRotation(_value: IVector3D): void {
+    notImplemented("setRotation");
+  }
+
+  public freezePosition(_freeze: boolean): void {
+    notImplemented("freezePosition");
+  }
+
+  public setCollision(_collision: boolean, _keepPhysics: boolean): void {
+    notImplemented("setCollision");
+  }
+
+  public setInvincible(_invincible: boolean): void {
+    notImplemented("setInvincible");
+  }
+
+  public setVisible(_visible: boolean): void {
+    notImplemented("setVisible");
+  }
+
+  public setAlpha(_alpha: number): void {
+    notImplemented("setAlpha");
+  }
+
+  public get alpha(): number {
+    return notImplemented("alpha");
+  }
+
+  public resetAlpha(): void {
+    notImplemented("resetAlpha");
+  }
+
+  public getOffsetFromInWorldCoords(_offsetX: number, _offsetY: number, _offsetZ: number): IVector3D {
+    return notImplemented("getOffsetFromInWorldCoords");
+  }
+
+  public getBoneIndexByName(_boneName: string): number {
+    return notImplemented("getBoneIndexByName");
+  }
+
+  public getWorldPositionOfBone(_boneIndex: number): IVector3D {
+    return notImplemented("getWorldPositionOfBone");
+  }
+
+  public getVariable(name: string): unknown | null {
+    const value = ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, name);
+    return value === undefined ? null : value;
+  }
+
+  public getSyncedMeta(key: string): unknown | undefined {
+    return ccmp.entities.getStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, key);
+  }
+
+  public hasSyncedMeta(key: string): boolean {
+    return ccmp.entities.hasStreamSyncedMeta(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId, key);
+  }
+
+  public getSyncedMetaKeys(): readonly string[] {
+    return ccmp.entities.getStreamSyncedMetaKeys(ccmp.entities.ENTITY_TYPE.Vehicle, this.remoteId);
+  }
+
+  public attachToEntity(
+    _target: IBaseObject,
+    _boneIndex: number,
+    _offset: IVector3D,
+    _rotation: IVector3D,
+    _p9: boolean,
+    _useSoftPinning: boolean,
+    _collision: boolean,
+    _isPed: boolean,
+    _vertexIndex: number,
+    _fixedRot: boolean,
+  ): void {
+    notImplemented("attachToEntity");
+  }
+
+  public detach(_useDetachVelocity: boolean, _collision: boolean): void {
+    notImplemented("detach");
+  }
+
+  public getSpeed(): number {
+    return notImplemented("getSpeed");
+  }
+
+  public isPlayingAnim(_dictionary: string, _name: string, _taskFlag: number): boolean {
+    return notImplemented("isPlayingAnim");
+  }
+
+  public get bodyHealth(): number {
+    return notImplemented("bodyHealth");
+  }
+
+  public get engineHealth(): number {
+    return notImplemented("engineHealth");
+  }
+
+  public get numberPlate(): string {
+    return this._ccmpVehicle.numberPlate ?? this._ccmpVehicle.numberPlateText;
+  }
+
+  public get isDead(): boolean {
+    return !this.isExists;
+  }
+
+  public setBodyHealth(_value: number): void {
+    notImplemented("setBodyHealth");
+  }
+
+  public setEngineHealth(_value: number): void {
+    notImplemented("setEngineHealth");
+  }
+
+  public setNumberPlate(_value: string): void {
+    notImplemented("setNumberPlate");
+  }
+
+  public explode(): void {
+    notImplemented("explode");
+  }
+
+  public getPedInSeat(_seat: number): number {
+    return notImplemented("getPedInSeat");
+  }
+
+  public setUndriveable(_toggle: boolean): void {
+    notImplemented("setUndriveable");
+  }
+
+  public get maxNumberOfPassengers(): number {
+    return notImplemented("maxNumberOfPassengers");
+  }
+
+  public get gear(): number {
+    return notImplemented("gear");
+  }
+
+  public get speed(): number {
+    return notImplemented("speed");
+  }
+
+  public get isEngineRunning(): boolean {
+    return notImplemented("isEngineRunning");
+  }
+
+  public setEngineOn(_toggle: boolean, _instantly: boolean, _otherwise: boolean): void {
+    notImplemented("setEngineOn");
+  }
+
+  public get lightsState(): ILightState {
+    return notImplemented("lightsState");
+  }
+
+  public get isLocked(): boolean {
+    return notImplemented("isLocked");
+  }
+
+  public setIsLocked(_value: boolean): void {
+    notImplemented("setIsLocked");
+  }
+
+  public setCustomPrimaryColour(_color: IRGB): void {
+    notImplemented("setCustomPrimaryColour");
+  }
+
+  public setCustomSecondaryColour(_color: IRGB): void {
+    notImplemented("setCustomSecondaryColour");
+  }
+
+  public get customPrimaryColour(): IRGB {
+    return notImplemented("customPrimaryColour");
+  }
+
+  public get customSecondaryColour(): IRGB {
+    return notImplemented("customSecondaryColour");
+  }
+
+  public setMod(_modType: number, _modIndex: number): void {
+    notImplemented("setMod");
+  }
+
+  public getMod(_modType: number): number {
+    return notImplemented("getMod");
+  }
+
+  public getNumMods(_modType: number): number {
+    return notImplemented("getNumMods");
+  }
+
+  public setNeonLightEnabled(_index: number, _toggle: boolean): void {
+    notImplemented("setNeonLightEnabled");
+  }
+
+  public setNeonLightsColour(_color: IRGB): void {
+    notImplemented("setNeonLightsColour");
+  }
+
+  public setWindowTint(_tintType: number): void {
+    notImplemented("setWindowTint");
+  }
+
+  public get windowTint(): number {
+    return notImplemented("windowTint");
+  }
+
+  public setWheelType(_wheelType: number): void {
+    notImplemented("setWheelType");
+  }
+
+  public get wheelType(): number {
+    return notImplemented("wheelType");
+  }
+
+  public setNumberPlateTextIndex(_index: number): void {
+    notImplemented("setNumberPlateTextIndex");
+  }
+
+  public get numberPlateTextIndex(): number {
+    return notImplemented("numberPlateTextIndex");
+  }
+
+  public setDoorOpen(_doorIndex: number, _loose: boolean, _openInstantly: boolean): void {
+    notImplemented("setDoorOpen");
+  }
+
+  public setDoorShut(_doorIndex: number, _instantly: boolean): void {
+    notImplemented("setDoorShut");
+  }
+
+  public setHandling(_field: string, _value: number): void {
+    notImplemented("setHandling");
+  }
+
+  public getHandling(_field: string): number {
+    return notImplemented("getHandling");
+  }
+
+  public setEnginePowerMultiplier(_value: number): void {
+    notImplemented("setEnginePowerMultiplier");
+  }
+
+  public setEngineTorqueMultiplier(_value: number): void {
+    notImplemented("setEngineTorqueMultiplier");
+  }
+
+  public modifyTopSpeed(_value: number): void {
+    notImplemented("modifyTopSpeed");
+  }
+
+  public setCheatPowerIncrease(_value: number): void {
+    notImplemented("setCheatPowerIncrease");
+  }
+
+  public toggleMod(_modType: number, _toggle: boolean): void {
+    notImplemented("toggleMod");
+  }
+
+  public setTyreSmokeColor(_r: number, _g: number, _b: number): void {
+    notImplemented("setTyreSmokeColor");
+  }
+
+  public setModColor1(_paintType: number, _color: number, _p3: number): void {
+    notImplemented("setModColor1");
+  }
+
+  public setExtraColours(_pearlescentColor: number, _wheelColor: number): void {
+    notImplemented("setExtraColours");
+  }
+
+  public setHeadlightColor(_colorIndex: number): void {
+    notImplemented("setHeadlightColor");
+  }
+
+  public setDashboardColor(_colorIndex: number): void {
+    notImplemented("setDashboardColor");
+  }
+
+  public setInteriorColor(_colorIndex: number): void {
+    notImplemented("setInteriorColor");
+  }
+
+  public getMaxBraking(): number {
+    return notImplemented("getMaxBraking");
+  }
+
+  public getAcceleration(): number {
+    return notImplemented("getAcceleration");
+  }
+
+  public getMaxTraction(): number {
+    return notImplemented("getMaxTraction");
+  }
+
+  public getModelMaxSpeed(): number {
+    return notImplemented("getModelMaxSpeed");
+  }
+}

--- a/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -13,6 +13,12 @@ interface ICCMPVehiclesApi {
   readonly count: number;
   getById(id: number): ICCMPNativeVehicle | null;
   getByRemoteId(remoteId: number): ICCMPNativeVehicle | null;
+  create(
+    model: string | number,
+    position: { x: number; y: number; z: number },
+    rotation?: { x: number; y: number; z: number },
+    options?: { dimension?: number; engine?: boolean; locked?: boolean },
+  ): ICCMPNativeVehicle | null;
 }
 
 interface ICCMPEventsApi {
@@ -43,10 +49,17 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   }
 
   public create(options: IVehicleCreateOptions): IVehicle {
-    void options;
-    throw new Error(
-      "CCMPVehiclesManager.create: client-side vehicle creation is not supported by CCMP. Use server-side ccmp.vehicles.create.",
-    );
+    const ccmpVehicle = this._getNativeVehiclesApi()?.create(options.model, options.position, options.rotation, {
+      dimension: options.dimension,
+      engine: options.engine,
+      locked: options.locked,
+    });
+
+    if (!ccmpVehicle) {
+      throw new Error(`CCMPVehiclesManager.create: ccmp.vehicles.create failed for model "${options.model}"`);
+    }
+
+    return this._register(ccmpVehicle);
   }
 
   public getDisplayNameFromVehicleModel(modelHash: number): string {

--- a/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -12,6 +12,7 @@ interface ICCMPVehiclesApi {
   readonly all: ICCMPNativeVehicle[];
   readonly count: number;
   getById(id: number): ICCMPNativeVehicle | null;
+  getByRemoteId(remoteId: number): ICCMPNativeVehicle | null;
 }
 
 interface ICCMPEventsApi {
@@ -20,6 +21,8 @@ interface ICCMPEventsApi {
 
 export class CCMPVehiclesManager implements IVehiclesManager {
   private readonly _vehicles = new Map<number, CCMPVehicle>();
+
+  private readonly _vehiclesByRemoteId = new Map<number, CCMPVehicle>();
 
   private readonly _iterator: IWorldObjectsIterator<CCMPVehicle> = {
     all: (): IterableIterator<CCMPVehicle> => this._filter(() => true),
@@ -80,7 +83,7 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   public findByID(id: number): IVehicle | null {
     const vehicle = this._vehicles.get(id) ?? null;
     if (vehicle && vehicle.isExists) return vehicle;
-    if (vehicle) this._vehicles.delete(id);
+    if (vehicle) this._unregister(vehicle);
 
     const ccmpVehicle = this._getNativeVehiclesApi()?.getById(id) ?? null;
     if (!ccmpVehicle) return null;
@@ -97,7 +100,14 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   }
 
   public findByRemoteID(remoteId: number): IVehicle | null {
-    return this.findByID(remoteId);
+    const vehicle = this._vehiclesByRemoteId.get(remoteId) ?? null;
+    if (vehicle && vehicle.isExists) return vehicle;
+    if (vehicle) this._unregister(vehicle);
+
+    const ccmpVehicle = this._getNativeVehiclesApi()?.getByRemoteId(remoteId) ?? null;
+    if (!ccmpVehicle) return null;
+
+    return this._register(ccmpVehicle);
   }
 
   public getByRemoteID(remoteId: number): IVehicle {
@@ -119,14 +129,33 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   }
 
   private _register(ccmpVehicle: ICCMPNativeVehicle): CCMPVehicle {
-    const existingVehicle = this._vehicles.get(ccmpVehicle.id) ?? null;
-    if (existingVehicle) return existingVehicle;
+    const existingVehicle = this._findRegistered(ccmpVehicle);
+    if (existingVehicle && existingVehicle.isExists) return existingVehicle;
+    if (existingVehicle) this._unregister(existingVehicle);
 
     const vehicle = new CCMPVehicle(ccmpVehicle, (destroyedVehicle) => {
-      this._vehicles.delete(destroyedVehicle.id);
+      this._unregister(destroyedVehicle);
     });
     this._vehicles.set(vehicle.id, vehicle);
+    if (vehicle.remoteId !== null) {
+      this._vehiclesByRemoteId.set(vehicle.remoteId, vehicle);
+    }
     return vehicle;
+  }
+
+  private _unregister(vehicle: CCMPVehicle): void {
+    this._vehicles.delete(vehicle.id);
+    if (vehicle.remoteId !== null) {
+      this._vehiclesByRemoteId.delete(vehicle.remoteId);
+    }
+  }
+
+  private _findRegistered(ccmpVehicle: ICCMPNativeVehicle): CCMPVehicle | null {
+    return (
+      (ccmpVehicle.remoteId === null ? null : (this._vehiclesByRemoteId.get(ccmpVehicle.remoteId) ?? null)) ??
+      this._vehicles.get(ccmpVehicle.id) ??
+      null
+    );
   }
 
   private _registerLifecycleEvents(): void {
@@ -140,9 +169,9 @@ export class CCMPVehiclesManager implements IVehiclesManager {
 
     eventsApi.on("vehicleDestroyed", (ccmpVehicle) => {
       if (!ccmpVehicle) return;
-      const vehicle = this._register(ccmpVehicle);
+      const vehicle = this._findRegistered(ccmpVehicle) ?? this._register(ccmpVehicle);
       RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityDestroyed, vehicle);
-      this._vehicles.delete(vehicle.id);
+      this._unregister(vehicle);
     });
 
     eventsApi.on("vehicleStreamIn", (ccmpVehicle) => {
@@ -153,7 +182,7 @@ export class CCMPVehiclesManager implements IVehiclesManager {
 
     eventsApi.on("vehicleStreamOut", (ccmpVehicle) => {
       if (!ccmpVehicle) return;
-      const vehicle = this._vehicles.get(ccmpVehicle.id) ?? this._register(ccmpVehicle);
+      const vehicle = this._findRegistered(ccmpVehicle) ?? this._register(ccmpVehicle);
       RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityStreamOut, vehicle);
     });
   }
@@ -161,7 +190,7 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   private *_filter(predicate: (vehicle: CCMPVehicle) => boolean): IterableIterator<CCMPVehicle> {
     for (const vehicle of this._vehicles.values()) {
       if (!vehicle.isExists) {
-        this._vehicles.delete(vehicle.id);
+        this._unregister(vehicle);
         continue;
       }
 
@@ -174,7 +203,7 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   private _pruneDestroyed(): void {
     for (const vehicle of this._vehicles.values()) {
       if (!vehicle.isExists) {
-        this._vehicles.delete(vehicle.id);
+        this._unregister(vehicle);
       }
     }
   }

--- a/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -1,67 +1,48 @@
 /// <reference types="@classic-mp/types/client" />
 
+import { RockMod } from "@RockMod/client/RockMod";
+import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
+import { type Vector2D, type Vector3D } from "@shared/common/utils";
 import { type IVehicle } from "../../common/vehicle/IVehicle";
 import { type IVehicleCreateOptions, type IVehiclesManager } from "../../common/vehicle/IVehiclesManager";
 import { type IWorldObjectsIterator } from "../../common/worldObject/IWorldObjectsIterator";
+import { CCMPVehicle, type ICCMPNativeVehicle } from "./CCMPVehicle";
 
-const EMPTY_VEHICLES: readonly IVehicle[] = [];
+interface ICCMPVehiclesApi {
+  readonly all: ICCMPNativeVehicle[];
+  readonly count: number;
+  getById(id: number): ICCMPNativeVehicle | null;
+}
 
-/**
- * Реализация `IVehiclesManager` под CCMP — **пустой пул** + native helper.
- *
- * ### Почему пусто
- *
- * RageMP даёт `mp.vehicles.toArray()`/`mp.vehicles.at(id)` — JS-side pool из
- * stream'нутых-в-радиус транспортных средств, заполняемый рантаймом. CCMP
- * такого пула на client-side не экспонирует:
- *  - `ccmp.natives.vehicle.createVehicle` создаёт локальный handle без id /
- *    replication / managed lifecycle.
- *  - `ccmp.vehicles.*` (server-side) спавнит реплицируемые vehicle-сущности,
- *    но клиент видит их данные через game state, а не как managed-IVehicle-
- *    инстансы в JS-pool'е.
- *
- * Поэтому iterator всегда пустой, `find*` возвращает null, `get*` и `deleteById` кидают.
- *
- * ### Hot path: `iterator.all()` на каждый render-tick
- *
- * Геймод-консьюмер `VehiclePartsInteractionController.syncVehicleProximity` →
- * `VehiclePartsInteractionService.syncState` → `VehicleService.getNearbyVehicles`
- * → `VehicleRepository.getNearby` → `VehicleRepository.getAll` → `iterator.all()`.
- * До этой реализации `VehiclesManager` был `createNotImplementedProxy`, и каждый
- * frame падал `CCMPVehiclesManager.iterator.all: not implemented yet`. Теперь
- * iterator возвращает пустой итератор — interaction-сервис тихо деградирует
- * (нет vehicles в радиусе → нет UI-хинтов / интеракций).
- *
- * ### `create(...)` под CCMP
- *
- * Не реализован осознанно: `VehicleRepository.create(...)` в геймоде ожидает
- * `IRockModVehicle` с id/remoteId/position/etc, а CCMP-натив `createVehicle`
- * возвращает только handle без id-mapping'а. Для корректной поддержки нужен
- * полноценный `CCMPVehicle`-класс и интеграция с server-side `ccmp.vehicles.*`
- * — отдельная задача. Сейчас бросаем понятную ошибку.
- *
- * ### `getDisplayNameFromVehicleModel`
- *
- * Этот метод **реализован** — натив `getDisplayNameFromVehicleModel`
- * (`0xB215AAC32D25D019`) экспонирован в `ccmp.natives.vehicle.*` и работает
- * без vehicle-pool'а (принимает только modelHash, возвращает GXT-ключ или
- * "CARNOTFOUND" для unknown-моделей).
- *
- * TODO: когда понадобится spawning vehicles из клиента (миссии, тестовые
- * объекты) — реализовать через `ccmp.natives.vehicle.createVehicle` + локальный
- * id-counter + `CCMPVehicle`-обёртку. Для синхронизированных vehicles нужна
- * server-side фабрика с `ccmp.vehicles.create` и net-events для распространения
- * id-mapping'а.
- */
+interface ICCMPEventsApi {
+  on(event: string, callback: (vehicle: ICCMPNativeVehicle | null) => void): void;
+}
+
 export class CCMPVehiclesManager implements IVehiclesManager {
-  // -- IVehiclesManager -----------------------------------------------------
+  private readonly _vehicles = new Map<number, CCMPVehicle>();
+
+  private readonly _iterator: IWorldObjectsIterator<CCMPVehicle> = {
+    all: (): IterableIterator<CCMPVehicle> => this._filter(() => true),
+    dimension: (value: number): IterableIterator<CCMPVehicle> => this._filter((vehicle) => vehicle.dimension === value),
+    range2D: (center: Vector2D, range: number): IterableIterator<CCMPVehicle> =>
+      this._filter((vehicle) => {
+        const position = vehicle.position;
+        const squaredDistance = (position.x - center.x) ** 2 + (position.y - center.y) ** 2;
+        return squaredDistance <= range * range;
+      }),
+    range3D: (center: Vector3D, range: number): IterableIterator<CCMPVehicle> =>
+      this._filter((vehicle) => vehicle.position.isInRange(center, range)),
+  };
+
+  public constructor() {
+    this._registerLifecycleEvents();
+    this.syncWithMpPool();
+  }
 
   public create(options: IVehicleCreateOptions): IVehicle {
     void options;
     throw new Error(
-      "CCMPVehiclesManager.create: создание vehicles на client-side под CCMP не поддерживается. " +
-        "Используйте server-side `ccmp.vehicles.create` (см. server/entities/ccmp/vehicle/*), " +
-        "либо вызывайте `ccmp.natives.vehicle.createVehicle` напрямую для локального vehicle-handle.",
+      "CCMPVehiclesManager.create: client-side vehicle creation is not supported by CCMP. Use server-side ccmp.vehicles.create.",
     );
   }
 
@@ -69,61 +50,136 @@ export class CCMPVehiclesManager implements IVehiclesManager {
     return ccmp.natives.vehicle.getDisplayNameFromVehicleModel(modelHash);
   }
 
-  // -- IEntitiesManager -----------------------------------------------------
-
   public syncWithMpPool(): void {
-    // No-op: client-side vehicle pool под CCMP отсутствует, синхронизировать нечего.
+    this._pruneDestroyed();
+
+    const ccmpVehicles = this._getNativeVehiclesApi();
+    if (!ccmpVehicles) return;
+
+    for (const ccmpVehicle of ccmpVehicles.all) {
+      this._register(ccmpVehicle);
+    }
   }
 
   public registerById(id: number): IVehicle {
-    throw new Error(
-      `CCMPVehiclesManager.registerById(${id}): client-side vehicle pool под CCMP отсутствует, ` +
-        "регистрировать vehicle по id невозможно.",
-    );
+    const existingVehicle = this.findByID(id);
+    if (existingVehicle) return existingVehicle;
+
+    const ccmpVehicle = this._getNativeVehiclesApi()?.getById(id) ?? null;
+    if (!ccmpVehicle) {
+      throw new Error(`CCMPVehiclesManager.registerById(${id}): vehicle not found.`);
+    }
+
+    return this._register(ccmpVehicle);
   }
 
   public unregisterById(id: number): IVehicle {
-    throw new Error(
-      `CCMPVehiclesManager.unregisterById(${id}): client-side vehicle pool под CCMP отсутствует, ` +
-        "разрегистрировать vehicle по id невозможно.",
-    );
+    return this.deleteById(id);
   }
 
-  // -- IBaseObjectsManager / IWorldObjectsManager ---------------------------
-
   public findByID(id: number): IVehicle | null {
-    void id;
-    return null;
+    const vehicle = this._vehicles.get(id) ?? null;
+    if (vehicle && vehicle.isExists) return vehicle;
+    if (vehicle) this._vehicles.delete(id);
+
+    const ccmpVehicle = this._getNativeVehiclesApi()?.getById(id) ?? null;
+    if (!ccmpVehicle) return null;
+
+    return this._register(ccmpVehicle);
   }
 
   public getByID(id: number): IVehicle {
-    throw new Error(`CCMPVehiclesManager.getByID(${id}): vehicle не найден (пул пуст под CCMP).`);
+    const vehicle = this.findByID(id);
+    if (!vehicle) {
+      throw new Error(`CCMPVehiclesManager.getByID(${id}): vehicle not found.`);
+    }
+    return vehicle;
   }
 
   public findByRemoteID(remoteId: number): IVehicle | null {
-    void remoteId;
-    return null;
+    return this.findByID(remoteId);
   }
 
   public getByRemoteID(remoteId: number): IVehicle {
-    throw new Error(`CCMPVehiclesManager.getByRemoteID(${remoteId}): vehicle не найден (пул пуст под CCMP).`);
+    const vehicle = this.findByRemoteID(remoteId);
+    if (!vehicle) {
+      throw new Error(`CCMPVehiclesManager.getByRemoteID(${remoteId}): vehicle not found.`);
+    }
+    return vehicle;
   }
 
   public deleteById(id: number): IVehicle {
-    throw new Error(`CCMPVehiclesManager.deleteById(${id}): vehicle не найден (пул пуст под CCMP).`);
+    const vehicle = this.getByID(id);
+    vehicle.destroy();
+    return vehicle;
   }
 
   public get iterator(): IWorldObjectsIterator<IVehicle> {
     return this._iterator;
   }
 
-  // Iterator реализован inline и возвращает пустые итераторы — hot path
-  // `VehiclePartsInteractionController.syncVehicleProximity` → `VehicleRepository.getNearby`
-  // теперь тихо деградирует вместо падения на каждом render-tick'е.
-  private readonly _iterator: IWorldObjectsIterator<IVehicle> = {
-    all: (): IterableIterator<IVehicle> => EMPTY_VEHICLES[Symbol.iterator](),
-    dimension: (): IterableIterator<IVehicle> => EMPTY_VEHICLES[Symbol.iterator](),
-    range2D: (): IterableIterator<IVehicle> => EMPTY_VEHICLES[Symbol.iterator](),
-    range3D: (): IterableIterator<IVehicle> => EMPTY_VEHICLES[Symbol.iterator](),
-  };
+  private _register(ccmpVehicle: ICCMPNativeVehicle): CCMPVehicle {
+    const existingVehicle = this._vehicles.get(ccmpVehicle.id) ?? null;
+    if (existingVehicle) return existingVehicle;
+
+    const vehicle = new CCMPVehicle(ccmpVehicle, (destroyedVehicle) => {
+      this._vehicles.delete(destroyedVehicle.id);
+    });
+    this._vehicles.set(vehicle.id, vehicle);
+    return vehicle;
+  }
+
+  private _registerLifecycleEvents(): void {
+    const eventsApi = ccmp as unknown as ICCMPEventsApi;
+
+    eventsApi.on("vehicleCreated", (ccmpVehicle) => {
+      if (!ccmpVehicle) return;
+      const vehicle = this._register(ccmpVehicle);
+      RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityCreated, vehicle);
+    });
+
+    eventsApi.on("vehicleDestroyed", (ccmpVehicle) => {
+      if (!ccmpVehicle) return;
+      const vehicle = this._register(ccmpVehicle);
+      RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityDestroyed, vehicle);
+      this._vehicles.delete(vehicle.id);
+    });
+
+    eventsApi.on("vehicleStreamIn", (ccmpVehicle) => {
+      if (!ccmpVehicle) return;
+      const vehicle = this._register(ccmpVehicle);
+      RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityStreamIn, vehicle);
+    });
+
+    eventsApi.on("vehicleStreamOut", (ccmpVehicle) => {
+      if (!ccmpVehicle) return;
+      const vehicle = this._vehicles.get(ccmpVehicle.id) ?? this._register(ccmpVehicle);
+      RockMod.instance.net.events.emitInternal(ClientInternalEventName.EntityStreamOut, vehicle);
+    });
+  }
+
+  private *_filter(predicate: (vehicle: CCMPVehicle) => boolean): IterableIterator<CCMPVehicle> {
+    for (const vehicle of this._vehicles.values()) {
+      if (!vehicle.isExists) {
+        this._vehicles.delete(vehicle.id);
+        continue;
+      }
+
+      if (predicate(vehicle)) {
+        yield vehicle;
+      }
+    }
+  }
+
+  private _pruneDestroyed(): void {
+    for (const vehicle of this._vehicles.values()) {
+      if (!vehicle.isExists) {
+        this._vehicles.delete(vehicle.id);
+      }
+    }
+  }
+
+  private _getNativeVehiclesApi(): ICCMPVehiclesApi | null {
+    return (ccmp as unknown as { vehicles?: ICCMPVehiclesApi }).vehicles ?? null;
+  }
 }

--- a/src/client/entities/common/baseObject/IBaseObject.ts
+++ b/src/client/entities/common/baseObject/IBaseObject.ts
@@ -7,7 +7,8 @@ export interface IBaseObjectOptions {
 
 export interface IBaseObject {
   get id(): number;
-  get remoteId(): number;
+  /** Server/network id for remote objects; null for client-only objects. */
+  get remoteId(): number | null;
   get type(): BaseObjectType;
   get isExists(): boolean;
   get handle(): number;

--- a/src/client/entities/ragemp/entity/RageEntity.ts
+++ b/src/client/entities/ragemp/entity/RageEntity.ts
@@ -11,8 +11,7 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
   }
 
   public get rotation(): Vector3D {
-    const { x, y, z } = this.mpEntity.rotation;
-    return new Vector3D(x, y, z);
+    return this._getNativeRotation() ?? this._getEntityRotationProperty() ?? new Vector3D(0, 0, this.heading);
   }
 
   protected constructor(options: IRageEntityOptions<T>) {
@@ -33,6 +32,10 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
 
   public setRotation(value: Vector3D): void {
     this.mpEntity.rotation = new mp.Vector3(value);
+
+    if (this._hasValidHandle()) {
+      mp.game.entity.setRotation(this.handle, value.x, value.y, value.z, 2, true);
+    }
   }
 
   public get forwardVector(): Vector3D {
@@ -144,5 +147,37 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
 
   public isPlayingAnim(dictionary: string, name: string, taskFlag: number): boolean {
     return mp.game.entity.isPlayingAnim(this.handle, dictionary, name, taskFlag);
+  }
+
+  private _getNativeRotation(): Vector3D | null {
+    if (!this._hasValidHandle()) return null;
+
+    try {
+      const rotation = mp.game.entity.getRotation(this.handle, 2);
+      if (!this._isVectorLike(rotation)) return null;
+      return new Vector3D(rotation.x, rotation.y, rotation.z);
+    } catch {
+      return null;
+    }
+  }
+
+  private _getEntityRotationProperty(): Vector3D | null {
+    const rotation = (this.mpEntity as { rotation?: unknown }).rotation;
+    if (!this._isVectorLike(rotation)) return null;
+    return new Vector3D(rotation.x, rotation.y, rotation.z);
+  }
+
+  private _hasValidHandle(): boolean {
+    return typeof this.handle === "number" && this.handle > 0;
+  }
+
+  private _isVectorLike(value: unknown): value is IVector3D {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      typeof (value as IVector3D).x === "number" &&
+      typeof (value as IVector3D).y === "number" &&
+      typeof (value as IVector3D).z === "number"
+    );
   }
 }

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -12,6 +12,7 @@ import { CCMPVehiclesManager } from "@RockMod/client/entities/ccmp/vehicle/CCMPV
 import { CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
 import { CCMPMarkersManager } from "@RockMod/client/entities/ccmp/marker/CCMPMarkersManager";
 import { CCMPBlipsManager } from "@RockMod/client/entities/ccmp/blip/CCMPBlipsManager";
+import { CCMPColshapesManager } from "@RockMod/client/entities/ccmp/colshape/CCMPColshapesManager";
 import { CCMPUtilsManager } from "@RockMod/client/utils/ccmp/CCMPUtilsManager";
 import { CCMPGraphicsManager } from "@RockMod/client/game/ccmp/graphics/CCMPGraphicsManager";
 import { CCMPUiManager } from "@RockMod/client/game/ccmp/ui/CCMPUiManager";
@@ -64,7 +65,8 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createColshapesManager(): ManagerReturn<"createColshapesManager"> {
-    return createNotImplementedProxy("CCMPColshapesManager");
+    const netManager = this._requireNetManager("createColshapesManager");
+    return new CCMPColshapesManager(netManager.events);
   }
 
   public createMarkersManager(): ManagerReturn<"createMarkersManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -10,6 +10,7 @@ import { CCMPPlayersManager } from "@RockMod/client/entities/ccmp/player/CCMPPla
 import { CCMPPedsManager } from "@RockMod/client/entities/ccmp/ped/CCMPPedsManager";
 import { CCMPVehiclesManager } from "@RockMod/client/entities/ccmp/vehicle/CCMPVehiclesManager";
 import { CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
+import { CCMPMarkersManager } from "@RockMod/client/entities/ccmp/marker/CCMPMarkersManager";
 import { CCMPUtilsManager } from "@RockMod/client/utils/ccmp/CCMPUtilsManager";
 import { CCMPGraphicsManager } from "@RockMod/client/game/ccmp/graphics/CCMPGraphicsManager";
 import { CCMPUiManager } from "@RockMod/client/game/ccmp/ui/CCMPUiManager";
@@ -65,7 +66,8 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createMarkersManager(): ManagerReturn<"createMarkersManager"> {
-    return createNotImplementedProxy("CCMPMarkersManager");
+    const netManager = this._requireNetManager("createMarkersManager");
+    return new CCMPMarkersManager(netManager.events);
   }
 
   public createObjectsManager(): ManagerReturn<"createObjectsManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -72,7 +72,8 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createPedsManager(): ManagerReturn<"createPedsManager"> {
-    return new CCMPPedsManager();
+    const netManager = this._requireNetManager("createPedsManager");
+    return new CCMPPedsManager(netManager.events);
   }
 
   public createPlayersManager(): ManagerReturn<"createPlayersManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -11,6 +11,7 @@ import { CCMPPedsManager } from "@RockMod/client/entities/ccmp/ped/CCMPPedsManag
 import { CCMPVehiclesManager } from "@RockMod/client/entities/ccmp/vehicle/CCMPVehiclesManager";
 import { CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
 import { CCMPMarkersManager } from "@RockMod/client/entities/ccmp/marker/CCMPMarkersManager";
+import { CCMPBlipsManager } from "@RockMod/client/entities/ccmp/blip/CCMPBlipsManager";
 import { CCMPUtilsManager } from "@RockMod/client/utils/ccmp/CCMPUtilsManager";
 import { CCMPGraphicsManager } from "@RockMod/client/game/ccmp/graphics/CCMPGraphicsManager";
 import { CCMPUiManager } from "@RockMod/client/game/ccmp/ui/CCMPUiManager";
@@ -58,7 +59,8 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createBlipsManager(): ManagerReturn<"createBlipsManager"> {
-    return createNotImplementedProxy("CCMPBlipsManager");
+    const netManager = this._requireNetManager("createBlipsManager");
+    return new CCMPBlipsManager(netManager.events);
   }
 
   public createColshapesManager(): ManagerReturn<"createColshapesManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -34,14 +34,17 @@ type ManagerReturn<K extends keyof IManagersFactory> = IManagersFactory[K] exten
   : never;
 
 export class CCMPManagersFactory implements IManagersFactory {
-  /**
-   * Сохраняем созданный `CCMPNetManager` потому что другим менеджерам
-   * (например, `CCMPPlayersManager`) нужен доступ к его событиям. Порядок
-   * создания в `RockMod` гарантирует, что `createNetManager` вызывается
-   * первым — мы можем безопасно полагаться на наличие `_netManager` в
-   * последующих фабричных методах.
-   */
   private _netManager: CCMPNetManager | null = null;
+
+  private _objectsManager: CCMPObjectsManager | null = null;
+
+  private _pedsManager: CCMPPedsManager | null = null;
+
+  private _playersManager: CCMPPlayersManager | null = null;
+
+  private _vehiclesManager: CCMPVehiclesManager | null = null;
+
+  private _syncedMetaBridgeRegistered = false;
 
   public createNetManager(): ManagerReturn<"createNetManager"> {
     this._netManager = new CCMPNetManager();
@@ -52,11 +55,32 @@ export class CCMPManagersFactory implements IManagersFactory {
     if (!this._netManager) {
       throw new Error(
         `CCMPManagersFactory.${forMethod}: ` +
-          "createNetManager() ещё не вызывался. Это нарушение контракта порядка " +
-          "фабричных методов в RockMod-конструкторе.",
+          "createNetManager() was not called yet. This violates RockMod manager factory order.",
       );
     }
     return this._netManager;
+  }
+
+  private _registerSyncedMetaBridgeIfReady(): void {
+    if (
+      this._syncedMetaBridgeRegistered ||
+      !this._netManager ||
+      !this._objectsManager ||
+      !this._pedsManager ||
+      !this._playersManager ||
+      !this._vehiclesManager
+    ) {
+      return;
+    }
+
+    new CCMPSyncedMetaBridge(this._netManager.events, {
+      objects: this._objectsManager,
+      peds: this._pedsManager,
+      players: this._playersManager,
+      vehicles: this._vehiclesManager,
+    }).register();
+
+    this._syncedMetaBridgeRegistered = true;
   }
 
   public createBlipsManager(): ManagerReturn<"createBlipsManager"> {
@@ -76,23 +100,23 @@ export class CCMPManagersFactory implements IManagersFactory {
 
   public createObjectsManager(): ManagerReturn<"createObjectsManager"> {
     const netManager = this._requireNetManager("createObjectsManager");
-    return new CCMPObjectsManager(netManager.events);
+    this._objectsManager = new CCMPObjectsManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._objectsManager;
   }
 
   public createPedsManager(): ManagerReturn<"createPedsManager"> {
     const netManager = this._requireNetManager("createPedsManager");
-    return new CCMPPedsManager(netManager.events);
+    this._pedsManager = new CCMPPedsManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._pedsManager;
   }
 
   public createPlayersManager(): ManagerReturn<"createPlayersManager"> {
     const netManager = this._requireNetManager("createPlayersManager");
-    const playersManager = new CCMPPlayersManager(netManager.events);
-    // Bridge для `streamSyncedMetaChange` создаётся здесь — ему нужен
-    // players manager для резолва `entityId → CCMPPlayer`, а events bus
-    // — для эмиссии `rm::syncedMetaChange` (на который уже подписан
-    // `CCMPDataHandler`, инстанцированный в `CCMPNetManager`).
-    new CCMPSyncedMetaBridge(netManager.events, playersManager).register();
-    return playersManager;
+    this._playersManager = new CCMPPlayersManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._playersManager;
   }
 
   public createUtilsManager(): ManagerReturn<"createUtilsManager"> {
@@ -100,7 +124,9 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createVehiclesManager(): ManagerReturn<"createVehiclesManager"> {
-    return new CCMPVehiclesManager();
+    this._vehiclesManager = new CCMPVehiclesManager();
+    this._registerSyncedMetaBridgeIfReady();
+    return this._vehiclesManager;
   }
 
   public createBrowserManager(): ManagerReturn<"createBrowserManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -36,6 +36,12 @@ type ManagerReturn<K extends keyof IManagersFactory> = IManagersFactory[K] exten
 export class CCMPManagersFactory implements IManagersFactory {
   private _netManager: CCMPNetManager | null = null;
 
+  private _blipsManager: CCMPBlipsManager | null = null;
+
+  private _colshapesManager: CCMPColshapesManager | null = null;
+
+  private _markersManager: CCMPMarkersManager | null = null;
+
   private _objectsManager: CCMPObjectsManager | null = null;
 
   private _pedsManager: CCMPPedsManager | null = null;
@@ -65,6 +71,9 @@ export class CCMPManagersFactory implements IManagersFactory {
     if (
       this._syncedMetaBridgeRegistered ||
       !this._netManager ||
+      !this._blipsManager ||
+      !this._colshapesManager ||
+      !this._markersManager ||
       !this._objectsManager ||
       !this._pedsManager ||
       !this._playersManager ||
@@ -74,6 +83,9 @@ export class CCMPManagersFactory implements IManagersFactory {
     }
 
     new CCMPSyncedMetaBridge(this._netManager.events, {
+      blips: this._blipsManager,
+      colshapes: this._colshapesManager,
+      markers: this._markersManager,
       objects: this._objectsManager,
       peds: this._pedsManager,
       players: this._playersManager,
@@ -85,17 +97,23 @@ export class CCMPManagersFactory implements IManagersFactory {
 
   public createBlipsManager(): ManagerReturn<"createBlipsManager"> {
     const netManager = this._requireNetManager("createBlipsManager");
-    return new CCMPBlipsManager(netManager.events);
+    this._blipsManager = new CCMPBlipsManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._blipsManager;
   }
 
   public createColshapesManager(): ManagerReturn<"createColshapesManager"> {
     const netManager = this._requireNetManager("createColshapesManager");
-    return new CCMPColshapesManager(netManager.events);
+    this._colshapesManager = new CCMPColshapesManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._colshapesManager;
   }
 
   public createMarkersManager(): ManagerReturn<"createMarkersManager"> {
     const netManager = this._requireNetManager("createMarkersManager");
-    return new CCMPMarkersManager(netManager.events);
+    this._markersManager = new CCMPMarkersManager(netManager.events);
+    this._registerSyncedMetaBridgeIfReady();
+    return this._markersManager;
   }
 
   public createObjectsManager(): ManagerReturn<"createObjectsManager"> {

--- a/src/client/factories/ccmp/CCMPManagersFactory.ts
+++ b/src/client/factories/ccmp/CCMPManagersFactory.ts
@@ -9,6 +9,7 @@ import { CCMPControlsManager } from "@RockMod/client/game/ccmp/controls/CCMPCont
 import { CCMPPlayersManager } from "@RockMod/client/entities/ccmp/player/CCMPPlayersManager";
 import { CCMPPedsManager } from "@RockMod/client/entities/ccmp/ped/CCMPPedsManager";
 import { CCMPVehiclesManager } from "@RockMod/client/entities/ccmp/vehicle/CCMPVehiclesManager";
+import { CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
 import { CCMPUtilsManager } from "@RockMod/client/utils/ccmp/CCMPUtilsManager";
 import { CCMPGraphicsManager } from "@RockMod/client/game/ccmp/graphics/CCMPGraphicsManager";
 import { CCMPUiManager } from "@RockMod/client/game/ccmp/ui/CCMPUiManager";
@@ -68,7 +69,8 @@ export class CCMPManagersFactory implements IManagersFactory {
   }
 
   public createObjectsManager(): ManagerReturn<"createObjectsManager"> {
-    return createNotImplementedProxy("CCMPObjectsManager");
+    const netManager = this._requireNetManager("createObjectsManager");
+    return new CCMPObjectsManager(netManager.events);
   }
 
   public createPedsManager(): ManagerReturn<"createPedsManager"> {

--- a/src/client/game/ccmp/storage/CCMPStorageManager.ts
+++ b/src/client/game/ccmp/storage/CCMPStorageManager.ts
@@ -1,53 +1,19 @@
 import { type IStorageManager } from "../../common/storage/IStorageManager";
 
-/**
- * In-memory реализация `IStorageManager` под CCMP.
- *
- * RageMP даёт `mp.storage.data` — персистентное JSON-K/V на диске между
- * сессиями. У CCMP нативного аналога client-side storage пока нет. Этот
- * MVP — обычный `Map` в памяти процесса:
- *  - Данные доступны в рамках одной сессии.
- *  - Не переживают переподключение/перезапуск игры.
- *
- * Этого достаточно для `CacheController` геймода: пустой кэш заставит
- * перезапросить данные с сервера, чуть менее эффективно но функционально.
- *
- * Долгосрочно: добавить persistent storage в CCMP-клиент (Rust) — файл в
- * `%APPDATA%/ccmp/storage/<server>.json` через `Deno.core.ops`, тогда
- * заменить этот класс на адаптер к ops.
- */
 export class CCMPStorageManager implements IStorageManager {
-  private readonly _data = new Map<string, unknown>();
-
-  public constructor() {
-    console.warn("[rock-mod] CCMPStorageManager uses in-memory storage; data will not persist between sessions");
-  }
-
   public getData<T>(key: string): T | null {
-    if (!this._data.has(key)) {
-      return null;
-    }
-    return (this._data.get(key) as T) ?? null;
+    return ccmp.storage.getItem<T>(key);
   }
 
   public setData<T>(key: string, value: T): void {
-    this._data.set(key, value);
+    ccmp.storage.setItem(key, value);
   }
 
   public removeData(key: string): void {
-    this._data.delete(key);
+    ccmp.storage.removeItem(key);
   }
 
   public clearData(prefix?: string): void {
-    if (!prefix) {
-      this._data.clear();
-      return;
-    }
-
-    for (const key of [...this._data.keys()]) {
-      if (key.startsWith(prefix)) {
-        this._data.delete(key);
-      }
-    }
+    ccmp.storage.clear(prefix);
   }
 }

--- a/src/client/net/ccmp/CCMPNetManager.ts
+++ b/src/client/net/ccmp/CCMPNetManager.ts
@@ -62,7 +62,7 @@ export class CCMPNetManager implements INetManager {
     this._rpcManager = new CCMPRPCManager();
     // DataHandler сначала, чтобы он успел подписаться на internal-bus до
     // первых эмиссий `rm::syncedMetaChange` от `CCMPSyncedMetaBridge`
-    // (регистрируется позже, когда все entity managers уже готовы).
+    // (registers later, when all stream-synced base-object managers are ready).
     this._dataHandler = new CCMPDataHandler(this._eventsManager);
     this._bridge = new CCMPEventsBridge(this._eventsManager);
     this._renderTicker = new CCMPRenderTicker();

--- a/src/client/net/ccmp/CCMPNetManager.ts
+++ b/src/client/net/ccmp/CCMPNetManager.ts
@@ -62,7 +62,7 @@ export class CCMPNetManager implements INetManager {
     this._rpcManager = new CCMPRPCManager();
     // DataHandler сначала, чтобы он успел подписаться на internal-bus до
     // первых эмиссий `rm::syncedMetaChange` от `CCMPSyncedMetaBridge`
-    // (создаётся позже в `CCMPManagersFactory.createPlayersManager`).
+    // (регистрируется позже, когда все entity managers уже готовы).
     this._dataHandler = new CCMPDataHandler(this._eventsManager);
     this._bridge = new CCMPEventsBridge(this._eventsManager);
     this._renderTicker = new CCMPRenderTicker();

--- a/src/client/net/ccmp/dataHandler/CCMPDataHandler.ts
+++ b/src/client/net/ccmp/dataHandler/CCMPDataHandler.ts
@@ -1,9 +1,9 @@
-import { type IEntity } from "../../../entities";
+import { type IBaseObject } from "../../../entities";
 import { type IDataHandler } from "../../common/dataHandler/IDataHandler";
 import { type CCMPEventsManager } from "../events/CCMPEventsManager";
 import { ClientInternalEventName } from "../../common/events/types";
 
-type DataHandlerCallback = (entity: IEntity, value: unknown, oldValue?: unknown) => void;
+type DataHandlerCallback = (object: IBaseObject, value: unknown, oldValue?: unknown) => void;
 
 /**
  * Реализация `IDataHandler` под CCMP поверх `rm::syncedMetaChange`.
@@ -24,7 +24,7 @@ export class CCMPDataHandler implements IDataHandler {
   public constructor(events: CCMPEventsManager) {
     events.onInternal({
       [ClientInternalEventName.SyncedMetaChange]: (
-        entity: IEntity,
+        object: IBaseObject,
         key: string,
         value: unknown,
         oldValue: unknown,
@@ -35,7 +35,7 @@ export class CCMPDataHandler implements IDataHandler {
         }
         for (const callback of [...callbacks]) {
           try {
-            callback(entity, value, oldValue);
+            callback(object, value, oldValue);
           } catch (error) {
             console.error(`[CCMPDataHandler] callback for key "${key}" failed:`, error);
           }

--- a/src/client/net/ccmp/events/CCMPSyncedMetaBridge.ts
+++ b/src/client/net/ccmp/events/CCMPSyncedMetaBridge.ts
@@ -1,52 +1,71 @@
 /// <reference types="@classic-mp/types/client" />
+import { type IEntity } from "@RockMod/client/entities";
+import { type CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
+import { type CCMPPedsManager } from "@RockMod/client/entities/ccmp/ped/CCMPPedsManager";
 import { type CCMPPlayersManager } from "@RockMod/client/entities/ccmp/player/CCMPPlayersManager";
+import { type CCMPVehiclesManager } from "@RockMod/client/entities/ccmp/vehicle/CCMPVehiclesManager";
 import { ClientInternalEventName } from "../../common/events/types";
 import { type CCMPEventsManager } from "./CCMPEventsManager";
 
+export interface ICCMPSyncedMetaBridgeManagers {
+  objects: CCMPObjectsManager;
+  peds: CCMPPedsManager;
+  players: CCMPPlayersManager;
+  vehicles: CCMPVehiclesManager;
+}
+
 /**
- * Переводит нативное CCMP-событие `streamSyncedMetaChange` в internal-bus
- * `rm::syncedMetaChange`.
- *
- * Вынесено в отдельный класс от `CCMPEventsBridge` из-за порядка
- * инстанцирования: bridge'у нужна ссылка на `CCMPPlayersManager` чтобы
- * резолвить `payload.entityId → CCMPPlayer`, а players manager создаётся
- * в `CCMPManagersFactory` **после** `CCMPNetManager` (внутри которого
- * живёт `CCMPEventsBridge`). Поэтому этот bridge создаётся вторым
- * шагом из `createPlayersManager`, когда обе зависимости уже доступны.
- *
- * Сейчас обслуживается только `entityType === Player` (=0) — на клиенте
- * rock-mod-CCMP других сущностей пока нет. Остальные типы тихо
- * игнорируем (snapshot прилетает на каждом stream-in, для несуществующих
- * на клиенте сущностей это нормально).
+ * Translates CCMP `streamSyncedMetaChange` into Rock-Mod's internal
+ * `rm::syncedMetaChange` for entity-backed types. UI/world-only wrappers
+ * (marker, blip, colshape) are intentionally left out because IDataHandler
+ * callbacks are typed as IEntity.
  */
 export class CCMPSyncedMetaBridge {
   private readonly _events: CCMPEventsManager;
 
-  private readonly _playersManager: CCMPPlayersManager;
+  private readonly _managers: ICCMPSyncedMetaBridgeManagers;
 
-  public constructor(events: CCMPEventsManager, playersManager: CCMPPlayersManager) {
+  private _registered = false;
+
+  public constructor(events: CCMPEventsManager, managers: ICCMPSyncedMetaBridgeManagers) {
     this._events = events;
-    this._playersManager = playersManager;
+    this._managers = managers;
   }
 
   public register(): void {
-    ccmp.on("streamSyncedMetaChange", (payload) => {
-      if (payload.entityType !== ccmp.entities.ENTITY_TYPE.Player) {
-        return;
-      }
+    if (this._registered) {
+      return;
+    }
+    this._registered = true;
 
-      const player = this._playersManager.findByRemoteId(payload.entityId);
-      if (!player) {
+    ccmp.on("streamSyncedMetaChange", (payload) => {
+      const entity = this._resolveEntity(payload.entityType, payload.entityId);
+      if (!entity) {
         return;
       }
 
       this._events.emitInternal(
         ClientInternalEventName.SyncedMetaChange,
-        player,
+        entity,
         payload.key,
         payload.newValue,
         payload.oldValue,
       );
     });
+  }
+
+  private _resolveEntity(entityType: number, entityId: number): IEntity | null {
+    switch (entityType) {
+      case ccmp.entities.ENTITY_TYPE.Player:
+        return this._managers.players.findByRemoteId(entityId);
+      case ccmp.entities.ENTITY_TYPE.Vehicle:
+        return this._managers.vehicles.findByRemoteID(entityId);
+      case ccmp.entities.ENTITY_TYPE.Object:
+        return this._managers.objects.findByRemoteID(entityId);
+      case ccmp.entities.ENTITY_TYPE.Ped:
+        return this._managers.peds.findByRemoteID(entityId);
+      default:
+        return null;
+    }
   }
 }

--- a/src/client/net/ccmp/events/CCMPSyncedMetaBridge.ts
+++ b/src/client/net/ccmp/events/CCMPSyncedMetaBridge.ts
@@ -1,5 +1,8 @@
 /// <reference types="@classic-mp/types/client" />
-import { type IEntity } from "@RockMod/client/entities";
+import { type IBaseObject } from "@RockMod/client/entities";
+import { type CCMPBlipsManager } from "@RockMod/client/entities/ccmp/blip/CCMPBlipsManager";
+import { type CCMPColshapesManager } from "@RockMod/client/entities/ccmp/colshape/CCMPColshapesManager";
+import { type CCMPMarkersManager } from "@RockMod/client/entities/ccmp/marker/CCMPMarkersManager";
 import { type CCMPObjectsManager } from "@RockMod/client/entities/ccmp/object/CCMPObjectsManager";
 import { type CCMPPedsManager } from "@RockMod/client/entities/ccmp/ped/CCMPPedsManager";
 import { type CCMPPlayersManager } from "@RockMod/client/entities/ccmp/player/CCMPPlayersManager";
@@ -8,6 +11,9 @@ import { ClientInternalEventName } from "../../common/events/types";
 import { type CCMPEventsManager } from "./CCMPEventsManager";
 
 export interface ICCMPSyncedMetaBridgeManagers {
+  blips: CCMPBlipsManager;
+  colshapes: CCMPColshapesManager;
+  markers: CCMPMarkersManager;
   objects: CCMPObjectsManager;
   peds: CCMPPedsManager;
   players: CCMPPlayersManager;
@@ -16,9 +22,7 @@ export interface ICCMPSyncedMetaBridgeManagers {
 
 /**
  * Translates CCMP `streamSyncedMetaChange` into Rock-Mod's internal
- * `rm::syncedMetaChange` for entity-backed types. UI/world-only wrappers
- * (marker, blip, colshape) are intentionally left out because IDataHandler
- * callbacks are typed as IEntity.
+ * `rm::syncedMetaChange` for stream-synced base objects.
  */
 export class CCMPSyncedMetaBridge {
   private readonly _events: CCMPEventsManager;
@@ -39,14 +43,14 @@ export class CCMPSyncedMetaBridge {
     this._registered = true;
 
     ccmp.on("streamSyncedMetaChange", (payload) => {
-      const entity = this._resolveEntity(payload.entityType, payload.entityId);
-      if (!entity) {
+      const object = this._resolveObject(payload.entityType, payload.entityId);
+      if (!object) {
         return;
       }
 
       this._events.emitInternal(
         ClientInternalEventName.SyncedMetaChange,
-        entity,
+        object,
         payload.key,
         payload.newValue,
         payload.oldValue,
@@ -54,7 +58,7 @@ export class CCMPSyncedMetaBridge {
     });
   }
 
-  private _resolveEntity(entityType: number, entityId: number): IEntity | null {
+  private _resolveObject(entityType: number, entityId: number): IBaseObject | null {
     switch (entityType) {
       case ccmp.entities.ENTITY_TYPE.Player:
         return this._managers.players.findByRemoteId(entityId);
@@ -64,6 +68,12 @@ export class CCMPSyncedMetaBridge {
         return this._managers.objects.findByRemoteID(entityId);
       case ccmp.entities.ENTITY_TYPE.Ped:
         return this._managers.peds.findByRemoteID(entityId);
+      case ccmp.entities.ENTITY_TYPE.Marker:
+        return this._managers.markers.findByRemoteID(entityId);
+      case ccmp.entities.ENTITY_TYPE.Blip:
+        return this._managers.blips.findByRemoteID(entityId);
+      case ccmp.entities.ENTITY_TYPE.Colshape:
+        return this._managers.colshapes.findByRemoteID(entityId);
       default:
         return null;
     }

--- a/src/client/net/common/dataHandler/IDataHandler.ts
+++ b/src/client/net/common/dataHandler/IDataHandler.ts
@@ -1,5 +1,5 @@
-import { type IEntity } from "@RockMod/client/entities";
+import { type IBaseObject } from "@RockMod/client/entities";
 
 export interface IDataHandler {
-  addDataHandler(key: string, callback: (entity: IEntity, value: unknown, oldValue?: unknown) => void): void;
+  addDataHandler(key: string, callback: (object: IBaseObject, value: unknown, oldValue?: unknown) => void): void;
 }

--- a/src/client/net/common/events/types.ts
+++ b/src/client/net/common/events/types.ts
@@ -1,4 +1,4 @@
-import { type IBaseObject, type IEntity, type IPlayer, type IVehicle } from "@RockMod/client/entities";
+import { type IBaseObject, type IPlayer, type IVehicle } from "@RockMod/client/entities";
 import { type IVector3D } from "@shared/common/utils";
 
 export enum ClientInternalEventName {
@@ -47,5 +47,10 @@ export interface IClientInternalEvents {
   [ClientInternalEventName.PlayerWeaponShot]: () => void;
   [ClientInternalEventName.Render]: () => void;
   [ClientInternalEventName.Click]: (options: IClickOptions) => void;
-  [ClientInternalEventName.SyncedMetaChange]: (entity: IEntity, key: string, value: unknown, oldValue: unknown) => void;
+  [ClientInternalEventName.SyncedMetaChange]: (
+    object: IBaseObject,
+    key: string,
+    value: unknown,
+    oldValue: unknown,
+  ) => void;
 }

--- a/src/client/net/common/events/types.ts
+++ b/src/client/net/common/events/types.ts
@@ -38,8 +38,8 @@ export interface IClientInternalEvents {
   [ClientInternalEventName.EntityDestroyed]: (object: IBaseObject) => void;
   [ClientInternalEventName.PlayerReady]: (localPlayer: IPlayer) => void;
   [ClientInternalEventName.BrowserDomReady]: () => void;
-  [ClientInternalEventName.EntityStreamIn]: (entity: IEntity) => void;
-  [ClientInternalEventName.EntityStreamOut]: (entity: IEntity) => void;
+  [ClientInternalEventName.EntityStreamIn]: (object: IBaseObject) => void;
+  [ClientInternalEventName.EntityStreamOut]: (object: IBaseObject) => void;
   [ClientInternalEventName.PlayerEnterVehicle]: (vehicle: IVehicle, seat: number) => void;
   [ClientInternalEventName.PlayerLeaveVehicle]: (vehicle: IVehicle, seat: number) => void;
   [ClientInternalEventName.PlayerDeath]: (player: IPlayer) => void;

--- a/src/client/net/ragemp/dataHandler/RageDataHandler.ts
+++ b/src/client/net/ragemp/dataHandler/RageDataHandler.ts
@@ -1,4 +1,4 @@
-import { type IEntity, type IEntityPoolRouter } from "@RockMod/client/entities";
+import { type IBaseObject, type IEntityPoolRouter } from "@RockMod/client/entities";
 import { type IDataHandler } from "@RockMod/client/net/common/dataHandler/IDataHandler";
 
 export class RageDataHandler implements IDataHandler {
@@ -8,7 +8,10 @@ export class RageDataHandler implements IDataHandler {
     this._entityPoolRouter = entityPoolRouter;
   }
 
-  public addDataHandler(key: string, callback: (entity: IEntity, value: unknown, oldValue?: unknown) => void): void {
+  public addDataHandler(
+    key: string,
+    callback: (object: IBaseObject, value: unknown, oldValue?: unknown) => void,
+  ): void {
     mp.events.addDataHandler(key, (mpEntity, value, oldValue) => {
       const entity = this._entityPoolRouter.resolveFromMp(mpEntity);
       if (!entity) {

--- a/src/server/entities/ccmp/baseObject/CCMPBaseObjectsManager.ts
+++ b/src/server/entities/ccmp/baseObject/CCMPBaseObjectsManager.ts
@@ -2,6 +2,8 @@ import { type IBaseObjectsManager, type IBaseObjectsManagerOptions } from "../..
 import { type CCMPBaseObject } from "./CCMPBaseObject";
 import { CCMPBaseObjectsIterator } from "./CCMPBaseObjectsIterator";
 import { type BaseObjectType } from "../../../../shared";
+import { RockMod } from "../../../RockMod";
+import { ServerInternalEventName } from "../../../net/common/events/types";
 
 export interface ICCMPBaseObjectsManagerOptions extends IBaseObjectsManagerOptions {}
 
@@ -49,15 +51,13 @@ export abstract class CCMPBaseObjectsManager<T extends CCMPBaseObject> implement
       throw new Error(`BaseObject [${this._baseObjectsType}] with id ${baseObject.id} already exists`);
     }
     this._baseObjects.set(baseObject.id, baseObject);
-    // TODO: emit ServerInternalEventName.EntityCreated and broadcast EntityCreated DTO
-    // through net.events once CCMPEventsManager is implemented (parity with RageBaseObjectsManager).
+    RockMod.instance.net.events.emitInternal(ServerInternalEventName.EntityCreated, baseObject);
   }
 
   protected unregisterBaseObject(baseObject: T): void {
     if (!this._baseObjects.delete(baseObject.id)) {
       throw new Error(`BaseObject [${this._baseObjectsType}] with id ${baseObject.id} not found`);
     }
-    // TODO: emit ServerInternalEventName.EntityDestroyed and broadcast EntityDestroyed DTO
-    // through net.events once CCMPEventsManager is implemented.
+    RockMod.instance.net.events.emitInternal(ServerInternalEventName.EntityDestroyed, baseObject);
   }
 }

--- a/src/server/entities/ccmp/blip/CCMPBlip.ts
+++ b/src/server/entities/ccmp/blip/CCMPBlip.ts
@@ -87,6 +87,14 @@ export class CCMPBlip extends CCMPWorldObject implements IBlip {
     this._ccmpBlip.dimension = value;
   }
 
+  public getNetData(name: string): unknown {
+    return this._ccmpBlip.getStreamSyncedMeta(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this._ccmpBlip.setStreamSyncedMeta(name, value);
+  }
+
   public setName(value: string): void {
     this._ccmpBlip.name = value;
   }

--- a/src/server/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/server/entities/ccmp/colshape/CCMPColshape.ts
@@ -39,6 +39,14 @@ export abstract class CCMPColshape extends CCMPWorldObject implements IColshape 
     return this._ccmpColshape.playersInside;
   }
 
+  public getNetData(name: string): unknown {
+    return this._ccmpColshape.getStreamSyncedMeta(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this._ccmpColshape.setStreamSyncedMeta(name, value);
+  }
+
   protected constructor(options: ICCMPColshapeOptions) {
     super();
     this._ccmpColshape = options.ccmpColshape;

--- a/src/server/entities/ccmp/marker/CCMPMarker.ts
+++ b/src/server/entities/ccmp/marker/CCMPMarker.ts
@@ -78,6 +78,14 @@ export class CCMPMarker extends CCMPWorldObject implements IMarker {
     this._ccmpMarker.dimension = value;
   }
 
+  public getNetData(name: string): unknown {
+    return this._ccmpMarker.getStreamSyncedMeta(name);
+  }
+
+  public setNetData(name: string, value: unknown): void {
+    this._ccmpMarker.setStreamSyncedMeta(name, value);
+  }
+
   public setVisible(value: boolean): void {
     this._ccmpMarker.visible = value;
   }

--- a/src/server/entities/ccmp/object/CCMPObject.ts
+++ b/src/server/entities/ccmp/object/CCMPObject.ts
@@ -12,6 +12,7 @@ export interface ICCMPObjectNative extends StreamSyncedMeta {
   rotation: { x: number; y: number; z: number };
   model: number;
   dimension: number;
+  alpha: number;
   destroy(): boolean;
 }
 
@@ -25,8 +26,6 @@ export class CCMPObject extends CCMPEntity implements IObject {
   private readonly _ccmpObject: ICCMPObjectNative;
 
   private readonly _onDestroy: (object: CCMPObject) => void;
-
-  private _alpha: number;
 
   public override get id(): number {
     return this._ccmpObject.id;
@@ -59,7 +58,7 @@ export class CCMPObject extends CCMPEntity implements IObject {
   }
 
   public get alpha(): number {
-    return this._alpha;
+    return this._ccmpObject.alpha;
   }
 
   protected override get ccmpMeta(): ICCMPObjectNative {
@@ -69,7 +68,7 @@ export class CCMPObject extends CCMPEntity implements IObject {
   public constructor(options: ICCMPObjectOptions) {
     super();
     this._ccmpObject = options.ccmpObject;
-    this._alpha = options.alpha;
+    this._ccmpObject.alpha = options.alpha;
     this._onDestroy = options.onDestroy;
   }
 
@@ -95,8 +94,7 @@ export class CCMPObject extends CCMPEntity implements IObject {
     this._ccmpObject.rotation = { x: value.x, y: value.y, z: value.z };
   }
 
-  // CCMP runtime currently has no object alpha op; keep an API-level cache.
   public setAlpha(value: number): void {
-    this._alpha = value;
+    this._ccmpObject.alpha = value;
   }
 }

--- a/src/server/entities/ccmp/object/CCMPObjectsManager.ts
+++ b/src/server/entities/ccmp/object/CCMPObjectsManager.ts
@@ -21,13 +21,12 @@ export class CCMPObjectsManager extends CCMPEntitiesManager<CCMPObject> implemen
       rotation.x,
       rotation.y,
       rotation.z,
+      { dimension, alpha },
     ) as ICCMPObjectNative | null;
 
     if (!ccmpObject) {
       throw new Error("CCMPObjectsManager.create: ccmp.objects.create failed (server full?)");
     }
-
-    ccmpObject.dimension = dimension;
 
     const object = new CCMPObject({
       ccmpObject,

--- a/src/server/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/server/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -60,7 +60,7 @@ export class CCMPVehicle extends CCMPEntity implements IVehicle {
   }
 
   public get numberPlate(): string {
-    return notImplemented("CCMPVehicle.numberPlate");
+    return this._ccmpVehicle.numberPlateText;
   }
 
   public get isLocked(): boolean {
@@ -148,8 +148,8 @@ export class CCMPVehicle extends CCMPEntity implements IVehicle {
     this._ccmpVehicle.engineOn = value;
   }
 
-  public setNumberPlate(_value: string): void {
-    notImplemented("CCMPVehicle.setNumberPlate");
+  public setNumberPlate(value: string): void {
+    this._ccmpVehicle.numberPlateText = value;
   }
 
   public setLocked(_value: boolean): void {
@@ -196,8 +196,8 @@ export class CCMPVehicle extends CCMPEntity implements IVehicle {
     notImplemented("CCMPVehicle.setWheelType");
   }
 
-  public setPlateType(_plateType: number): void {
-    notImplemented("CCMPVehicle.setPlateType");
+  public setPlateType(plateType: number): void {
+    this._ccmpVehicle.numberPlateType = plateType;
   }
 
   public explode(): void {

--- a/src/server/entities/ragemp/entity/RageEntity.ts
+++ b/src/server/entities/ragemp/entity/RageEntity.ts
@@ -1,21 +1,26 @@
 import { type IEntity } from "../../common/entity/IEntity";
 import { type IRageWorldObjectOptions, RageWorldObject } from "../worldObject/RageWorldObject";
-import { Vector3D } from "../../../../shared/common/utils";
+import { type IVector3D, Vector3D } from "../../../../shared/common/utils";
 
-export interface IRageEntityOptions<T extends EntityMp> extends IRageWorldObjectOptions<T> {}
+export interface IRageEntityOptions<T extends EntityMp> extends IRageWorldObjectOptions<T> {
+  rotation?: IVector3D;
+}
 
 export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> implements IEntity {
+  private _rotation: IVector3D | undefined;
+
   public get model(): number {
     return this.mpEntity.model;
   }
 
   public get rotation(): Vector3D {
-    const { x, y, z } = this.mpEntity.rotation;
+    const { x, y, z } = this._getEntityRotationProperty() ?? this._rotation ?? new Vector3D(0, 0, 0);
     return new Vector3D(x, y, z);
   }
 
   protected constructor(options: IRageEntityOptions<T>) {
     super(options);
+    this._rotation = options.rotation;
   }
 
   public setModel(value: string): void {
@@ -23,6 +28,7 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
   }
 
   public setRotation(value: Vector3D): void {
+    this._rotation = value;
     this.mpEntity.rotation = new mp.Vector3(value);
   }
 
@@ -32,5 +38,21 @@ export abstract class RageEntity<T extends EntityMp> extends RageWorldObject<T> 
 
   public setNetData(name: string, value: unknown): void {
     this.mpEntity.setVariable(name, value);
+  }
+
+  private _getEntityRotationProperty(): IVector3D | null {
+    const rotation = (this.mpEntity as { rotation?: unknown }).rotation;
+    if (!this._isVectorLike(rotation)) return null;
+    return rotation;
+  }
+
+  private _isVectorLike(value: unknown): value is IVector3D {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      typeof (value as IVector3D).x === "number" &&
+      typeof (value as IVector3D).y === "number" &&
+      typeof (value as IVector3D).z === "number"
+    );
   }
 }

--- a/src/server/entities/ragemp/object/RageObjectsManager.ts
+++ b/src/server/entities/ragemp/object/RageObjectsManager.ts
@@ -21,7 +21,7 @@ export class RageObjectsManager extends RageEntitiesManager<RageObject> implemen
     });
     mpEntity.isExists = (): boolean => mp.objects.exists(mpEntity);
 
-    const object = new RageObject({ mpEntity });
+    const object = new RageObject({ mpEntity, rotation });
     this.registerBaseObject(object);
 
     return object;

--- a/src/server/entities/ragemp/ped/RagePedsManager.ts
+++ b/src/server/entities/ragemp/ped/RagePedsManager.ts
@@ -21,7 +21,7 @@ export class RagePedsManager extends RageEntitiesManager<RagePed> implements IPe
     });
     mpEntity.isExists = (): boolean => mp.peds.exists(mpEntity);
 
-    const ped = new RagePed({ mpEntity });
+    const ped = new RagePed({ mpEntity, rotation });
     this.registerBaseObject(ped);
 
     return ped;

--- a/src/server/entities/ragemp/vehicle/RageVehiclesManager.ts
+++ b/src/server/entities/ragemp/vehicle/RageVehiclesManager.ts
@@ -23,7 +23,7 @@ export class RageVehiclesManager extends RageEntitiesManager<RageVehicle> implem
     mpEntity.rotation = new mp.Vector3(rotation);
     mpEntity.isExists = (): boolean => mp.vehicles.exists(mpEntity);
 
-    const vehicle = new RageVehicle({ mpEntity });
+    const vehicle = new RageVehicle({ mpEntity, rotation });
     this.registerBaseObject(vehicle);
 
     return vehicle;


### PR DESCRIPTION
## Rock-Mod 0.22.0

This release continues the development of CCMP integration and brings the client-side implementation much closer to full support through the unified Rock-Mod API.

### What's New

- Added support for CCMP local entities on the client.
- Implemented client-side adapters for CCMP vehicle, object, marker, blip, and colshape entities.
- Expanded vehicle API support: plates, seat entry, styling, offset lookup, and lifecycle event handling.
- Added lifecycle event handling for ped, object, marker, blip, and colshape entities.
- Improved synced meta support for entity, ped, marker, blip, and base object data handlers.
- CCMP storage now uses client-side local storage.

### Fixes

- Fixed CCMP entity remote ID handling.
- Bridged CCMP streamed peds into Rock-Mod.
- Hardened vehicle adapter handle APIs.
- Stabilized entity rotation reads in RageMP.

### Infrastructure

- Renamed the CI branch from `development` to `dev`.
- Updated GitHub Actions and npm cache settings.
- Updated `@classic-mp/types` to `1.6.0`.