### PR TITLE
Release 0.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@swc/helpers": "^0.5.15"
       },
       "devDependencies": {
-        "@classic-mp/types": "^1.7.0",
+        "@classic-mp/types": "^1.7.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@classic-mp/types": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.7.0.tgz",
-      "integrity": "sha512-pLzGlpr0CfAGqui/Et7Lu2dD/IsK+Jven99uxpWsBOmGCgt8wpcqcpNXogH3zAy6DRCxF3FdcY5aos3kSnzSDA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.7.1.tgz",
+      "integrity": "sha512-1/GlptDTO0m+4kTFXmeFcfH/jHiqZTS9Kz9WJTQtKn3NHQhgRmRn0o6ZOuGPL/bAmS3KzMPE97nGyiNZgrxkcw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@swc/helpers": "^0.5.15"
   },
   "devDependencies": {
-    "@classic-mp/types": "^1.7.0",
+    "@classic-mp/types": "^1.7.1",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/src/client/game/ccmp/graphics/CCMPGraphicsManager.ts
+++ b/src/client/game/ccmp/graphics/CCMPGraphicsManager.ts
@@ -63,25 +63,13 @@ export class CCMPGraphicsManager implements IGraphicsManager {
     const outline = options?.outline ?? true;
     const centre = options?.centre ?? false;
 
-    const hud = ccmp.natives.hud;
-
-    hud.setTextFont(font);
-    // Натив `SET_TEXT_SCALE(scale, size)` — первый параметр обычно игнорируется,
-    // эффективный размер задаётся вторым. RageMP передаёт оба из массива
-    // `[scaleX, scaleY]` — повторяем тот же контракт.
-    hud.setTextScale(scaleX, scaleY);
-    hud.setTextColour(r, g, b, a);
-    if (outline) {
-      hud.setTextOutline();
-    }
-    if (centre) {
-      hud.setTextCentre(true);
-    }
-
-    hud.beginTextCommandDisplayText("STRING");
-    hud.addTextComponentSubstringPlayerName(text);
-    // p2 — `unk_const_0` (введён в b2699); 0 — стандартное значение.
-    hud.endTextCommandDisplayText(position.x, position.y, 0);
+    ccmp.graphics.drawText(text, position.x, position.y, {
+      font,
+      scale: [scaleX, scaleY],
+      color: [r, g, b, a],
+      outline,
+      centre,
+    });
   }
 
   public world3dToScreen2d(position: IVector3D): IVector2D | null {


### PR DESCRIPTION
## Rock-Mod v0.23.1

This patch release improves CCMP client rendering compatibility and updates Classic MP typings.

### Fixed

- Fixed CCMP screen text rendering by routing `drawText` through the CCMP graphics API instead of low-level HUD natives.

### Changed

- Updated `@classic-mp/types` from `1.7.0` to `1.7.1`.

### Notes

- No breaking API changes are expected in this release.