### PR TITLE
Release 0.25.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/server/entities/ccmp/ped/CCMPPedsManager.ts
+++ b/src/server/entities/ccmp/ped/CCMPPedsManager.ts
@@ -1,4 +1,5 @@
 import { type IPedCreateOptions, type IPedsManager } from "../../common/ped/IPedsManager";
+import type { PedExtras } from "@classic-mp/types/server";
 import { CCMPEntitiesManager } from "../entity/CCMPEntitiesManager";
 import { CCMPPed } from "./CCMPPed";
 
@@ -12,13 +13,18 @@ export class CCMPPedsManager extends CCMPEntitiesManager<CCMPPed> implements IPe
   }
 
   public create(options: ICCMPPedCreateOptions): CCMPPed {
-    const { model, frozen, invincible = false, position, rotation, dimension } = options;
+    const { model, frozen, invincible = false, placeOnGround, position, rotation, dimension } = options;
 
-    const ccmpPed = ccmp.peds.create(ccmp.hash(model), position.x, position.y, position.z, rotation.z, {
+    const extras: PedExtras = {
       dimension,
       frozen,
       invincible,
-    });
+    };
+    if (placeOnGround !== undefined) {
+      extras.placeOnGround = placeOnGround;
+    }
+
+    const ccmpPed = ccmp.peds.create(ccmp.hash(model), position.x, position.y, position.z, rotation.z, extras);
     if (!ccmpPed) {
       throw new Error("CCMPPedsManager.create: ccmp.peds.create failed (server full?)");
     }

--- a/src/server/entities/common/ped/IPedsManager.ts
+++ b/src/server/entities/common/ped/IPedsManager.ts
@@ -4,6 +4,7 @@ import { type IPed } from "./IPed";
 export interface IPedCreateOptions extends IEntityCreateOptions {
   frozen: boolean;
   invincible?: boolean;
+  placeOnGround?: boolean;
 }
 
 export interface IPedsManager extends IEntitiesManager<IPed> {


### PR DESCRIPTION
## 0.25.1

This release adds support for placing CCMP peds on the ground during creation.

### Added
- Added the `placeOnGround` option to ped creation options.
- Forwarded `placeOnGround` to CCMP ped creation extras when provided.