### PR TITLE
Release 0.25.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.25.1",
+      "version": "0.25.2",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/entities/common/router/IEntityPoolRouter.ts
+++ b/src/client/entities/common/router/IEntityPoolRouter.ts
@@ -4,6 +4,6 @@ import type { IBaseObjectDto } from "@shared/entities";
 export interface IEntityPoolRouter {
   registerByDto(entity: IBaseObjectDto): IEntity | null;
   unregisterByDto(entity: IBaseObjectDto): IEntity | null;
-  registerFromMp(mpEntity: EntityMp): IEntity | null;
-  resolveFromMp(mpEntity: EntityMp): IEntity | null;
+  registerFromMp(mpEntity: EntityMp | null | undefined): IEntity | null;
+  resolveFromMp(mpEntity: EntityMp | null | undefined): IEntity | null;
 }

--- a/src/client/entities/ragemp/router/RageEntityPoolRouter.ts
+++ b/src/client/entities/ragemp/router/RageEntityPoolRouter.ts
@@ -40,13 +40,21 @@ export class RageEntityPoolRouter implements IEntityPoolRouter {
     });
   }
 
-  public registerFromMp(mpEntity: EntityMp): IEntity | null {
+  public registerFromMp(mpEntity: EntityMp | null | undefined): IEntity | null {
+    if (!mpEntity) {
+      return null;
+    }
+
     const entityType = mpEntity.type as unknown as BaseObjectType;
 
     return this._withEntityPool(entityType, (pool) => pool.registerById(mpEntity.id));
   }
 
-  public resolveFromMp(mpEntity: EntityMp): IEntity | null {
+  public resolveFromMp(mpEntity: EntityMp | null | undefined): IEntity | null {
+    if (!mpEntity) {
+      return null;
+    }
+
     const entityType = mpEntity.type as unknown as BaseObjectType;
 
     return this._withEntityPool(entityType, (pool) => pool.findByID(mpEntity.id));

--- a/src/client/net/ragemp/events/RageEventsBridge.ts
+++ b/src/client/net/ragemp/events/RageEventsBridge.ts
@@ -11,6 +11,8 @@ export class RageEventsBridge implements IEventsBridge {
 
   private readonly _entityPoolRouter: IEntityPoolRouter;
 
+  private _lastEnteredVehicle: IVehicle | null = null;
+
   public constructor(events: IEventsManager, entityPoolRouter: IEntityPoolRouter) {
     this._events = events;
     this._entityPoolRouter = entityPoolRouter;
@@ -77,20 +79,23 @@ export class RageEventsBridge implements IEventsBridge {
       },
 
       playerEnterVehicle: (mpVehicle, seat) => {
-        const vehicle = this._entityPoolRouter.registerFromMp(mpVehicle) as IVehicle;
+        const vehicle = this._entityPoolRouter.registerFromMp(mpVehicle) as IVehicle | null;
         if (!vehicle) {
           return;
         }
 
+        this._lastEnteredVehicle = vehicle;
         this._events.emitInternal(ClientInternalEventName.PlayerEnterVehicle, vehicle, seat);
       },
 
       playerLeaveVehicle: (mpVehicle, seat) => {
-        const vehicle = this._entityPoolRouter.resolveFromMp(mpVehicle) as IVehicle;
+        const vehicle =
+          (this._entityPoolRouter.resolveFromMp(mpVehicle) as IVehicle | null) ?? this._lastEnteredVehicle;
         if (!vehicle) {
           return;
         }
 
+        this._lastEnteredVehicle = null;
         this._events.emitInternal(ClientInternalEventName.PlayerLeaveVehicle, vehicle, seat);
       },
 

--- a/src/server/entities/ccmp/blip/CCMPBlipsManager.ts
+++ b/src/server/entities/ccmp/blip/CCMPBlipsManager.ts
@@ -22,19 +22,31 @@ export class CCMPBlipsManager extends CCMPWorldObjectsManager<CCMPBlip> implemen
       drawDistance = 0,
       global = false,
       name = "",
-      rotation = 0,
       shortRange = false,
     } = options;
 
-    const ccmpBlip = ccmp.blips.create(sprite, position.x, position.y, position.z, color, scale, {
+    const createOptions: {
+      name: string;
+      alpha: number;
+      drawDistance: number;
+      global: boolean;
+      shortRange: boolean;
+      dimension?: number;
+      rotation?: number;
+    } = {
       name,
       alpha,
       drawDistance,
       global,
       shortRange,
-      rotation,
       dimension,
-    });
+    };
+
+    if (options.rotation !== undefined) {
+      createOptions.rotation = options.rotation;
+    }
+
+    const ccmpBlip = ccmp.blips.create(sprite, position.x, position.y, position.z, color, scale, createOptions);
     if (!ccmpBlip) {
       throw new Error("CCMPBlipsManager.create: ccmp.blips.create failed (server full?)");
     }


### PR DESCRIPTION
## 0.25.2

This release includes two bug fixes for CCMP blips and RageMP vehicle events.

### Fixed
- Fixed CCMP blip creation so the default `rotation` value is no longer sent unless explicitly provided.
- Fixed RageMP vehicle leave handling so the player leave vehicle event is still emitted when the vehicle reference is already unavailable during destroy/leave flow.