### PR TITLE
Release 0.25.3

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Vendored runtime declarations contain quoted method names whose semantics
+# change when Prettier removes the quotes (for example, "new" becomes new).
+src/client/@types/
+src/server/@types/

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@swc/helpers": "^0.5.15"
       },
       "devDependencies": {
-        "@classic-mp/types": "^1.8.0",
+        "@classic-mp/types": "^1.9.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@classic-mp/types": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.8.0.tgz",
-      "integrity": "sha512-DAiKKCeUjqxeuPE3GxxBGJRZRQKqZtQJRQdD/ic3KhbeuOr23AaWgJB8zxBk3dzWs5G1y/AI04n+NSvaX268PQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@classic-mp/types/-/types-1.9.0.tgz",
+      "integrity": "sha512-+ANvJJL9KY4CMr+ZPHEMbN97S0gs4MgVEW4/RGe1N90Y+8vNI+xaaJbxjIdhMoznjvuLci3AIP19NJPKhvN+JQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.25.2",
+      "version": "0.25.3",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@swc/helpers": "^0.5.15"
   },
   "devDependencies": {
-    "@classic-mp/types": "^1.8.0",
+    "@classic-mp/types": "^1.9.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-terser": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/client/entities/ccmp/colshape/CCMPColshape.ts
@@ -53,8 +53,7 @@ export class CCMPColshape implements IColshape {
   }
 
   public get key(): string | undefined {
-    const value = this.getSyncedMeta("key");
-    return typeof value === "string" ? value : undefined;
+    return this._ccmpColshape.key;
   }
 
   public setPosition(_value: IVector3D): void {

--- a/src/client/entities/ccmp/ped/CCMPPed.ts
+++ b/src/client/entities/ccmp/ped/CCMPPed.ts
@@ -88,8 +88,7 @@ export class CCMPPed implements IPed {
   }
 
   public get rotation(): Vector3D {
-    const { x, y, z } = this._ccmpPed.rotation;
-    return new Vector3D(x, y, z);
+    return new Vector3D(0, 0, this._ccmpPed.heading);
   }
 
   public setRotation(value: IVector3D): void {

--- a/src/client/entities/ccmp/player/CCMPPlayersManager.ts
+++ b/src/client/entities/ccmp/player/CCMPPlayersManager.ts
@@ -107,13 +107,7 @@ export class CCMPPlayersManager implements IPlayersManager {
 
     // 2) Prepopulate уже-существующих remote-игроков из CCMP-runtime'а.
     // `ccmp.players.all` исключает local (см. js_runtime.rs::setup_globals).
-    try {
-      for (const ccmpPlayer of ccmp.players.all as unknown as ICCMPNativePlayer[]) {
-        this._ensurePlayer(ccmpPlayer.id, ccmpPlayer.name ?? "", /* isLocal */ false);
-      }
-    } catch (error) {
-      console.warn("[CCMPPlayersManager] failed to prepopulate from ccmp.players.all:", error);
-    }
+    this._syncRemotePlayersFromRuntime();
 
     // 3) Fast-path: попытка эмитнуть rm::playerReady сразу. Если local не
     // готов (handshake ещё не отработал) — пропускаем, дальше connectionStateChanged
@@ -185,9 +179,9 @@ export class CCMPPlayersManager implements IPlayersManager {
   // -- IEntitiesManager -----------------------------------------------------
 
   public syncWithMpPool(): void {
-    // RageMP-pool API не существует под CCMP. Игроки управляются событиями
-    // `rm::playerConnected`/`rm::playerDisconnected`, prepopulation идёт
-    // из `ccmp.players.all` в конструкторе. No-op для соответствия интерфейсу.
+    this._syncRemotePlayersFromRuntime();
+    this._syncLocalPlayerFromRuntime();
+    this._tryEmitLocalPlayerReady();
   }
 
   public registerById(id: number): CCMPPlayer {
@@ -269,6 +263,28 @@ export class CCMPPlayersManager implements IPlayersManager {
     });
   }
 
+  private _syncRemotePlayersFromRuntime(): void {
+    try {
+      for (const ccmpPlayer of ccmp.players.all as unknown as ICCMPNativePlayer[]) {
+        this._ensurePlayer(ccmpPlayer.id, ccmpPlayer.name ?? "", /* isLocal */ false);
+      }
+    } catch (error) {
+      console.warn("[CCMPPlayersManager] failed to sync from ccmp.players.all:", error);
+    }
+  }
+
+  private _syncLocalPlayerFromRuntime(): void {
+    let nativeLocal: ICCMPNativePlayer | null;
+    try {
+      nativeLocal = ccmp.players.local as unknown as ICCMPNativePlayer | null;
+    } catch {
+      return;
+    }
+    if (nativeLocal) {
+      this._ensurePlayer(nativeLocal.id, nativeLocal.name ?? "", /* isLocal */ true);
+    }
+  }
+
   /**
    * Идемпотентная точка создания/обновления CCMPPlayer. Все источники
    * (events, prepopulation, fast-path) проходят сюда.
@@ -303,6 +319,7 @@ export class CCMPPlayersManager implements IPlayersManager {
    */
   private _tryEmitLocalPlayerReady(): void {
     if (this._localPlayer) {
+      this._syncLocalPlayerFromRuntime();
       return;
     }
 

--- a/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -7,6 +7,10 @@ import { type ILightState, type IVehicle } from "../../common/vehicle/IVehicle";
 
 export type ICCMPNativeVehicle = CcmpVehicle;
 
+type CcmpVehicleWithNumberPlateType = CcmpVehicle & {
+  setNumberPlateType(index: number): void;
+};
+
 export class CCMPVehicle implements IVehicle {
   private _destroyed = false;
 
@@ -336,12 +340,12 @@ export class CCMPVehicle implements IVehicle {
     return this._ccmpVehicle.wheelType;
   }
 
-  public setNumberPlateTextIndex(index: number): void {
-    this._ccmpVehicle.setNumberPlateTextIndex(index);
+  public setNumberPlateType(index: number): void {
+    (this._ccmpVehicle as CcmpVehicleWithNumberPlateType).setNumberPlateType(index);
   }
 
-  public get numberPlateTextIndex(): number {
-    return this._ccmpVehicle.numberPlateTextIndex;
+  public get numberPlateType(): number {
+    return this._ccmpVehicle.numberPlateType;
   }
 
   public setDoorOpen(doorIndex: number, loose: boolean, openInstantly: boolean): void {

--- a/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -65,7 +65,12 @@ export class CCMPVehiclesManager implements IVehiclesManager {
     if (options.numberPlate !== undefined) createOptions.numberPlate = options.numberPlate;
     if (options.numberPlateType !== undefined) createOptions.numberPlateType = options.numberPlateType;
 
-    const ccmpVehicle = this._getNativeVehiclesApi()?.create(options.model, options.position, options.rotation, createOptions);
+    const ccmpVehicle = this._getNativeVehiclesApi()?.create(
+      options.model,
+      options.position,
+      options.rotation,
+      createOptions,
+    );
 
     if (!ccmpVehicle) {
       throw new Error(`CCMPVehiclesManager.create: ccmp.vehicles.create failed for model "${options.model}"`);

--- a/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/client/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -18,7 +18,13 @@ interface ICCMPVehiclesApi {
     model: string | number,
     position: { x: number; y: number; z: number },
     rotation?: { x: number; y: number; z: number },
-    options?: { dimension?: number; engine?: boolean; locked?: boolean },
+    options?: {
+      dimension?: number;
+      engine?: boolean;
+      locked?: boolean;
+      numberPlate?: string;
+      numberPlateType?: number;
+    },
   ): ICCMPNativeVehicle | null;
 }
 
@@ -50,11 +56,16 @@ export class CCMPVehiclesManager implements IVehiclesManager {
   }
 
   public create(options: IVehicleCreateOptions): IVehicle {
-    const ccmpVehicle = this._getNativeVehiclesApi()?.create(options.model, options.position, options.rotation, {
+    const createOptions: NonNullable<Parameters<ICCMPVehiclesApi["create"]>[3]> = {
       dimension: options.dimension,
       engine: options.engine,
       locked: options.locked,
-    });
+    };
+
+    if (options.numberPlate !== undefined) createOptions.numberPlate = options.numberPlate;
+    if (options.numberPlateType !== undefined) createOptions.numberPlateType = options.numberPlateType;
+
+    const ccmpVehicle = this._getNativeVehiclesApi()?.create(options.model, options.position, options.rotation, createOptions);
 
     if (!ccmpVehicle) {
       throw new Error(`CCMPVehiclesManager.create: ccmp.vehicles.create failed for model "${options.model}"`);

--- a/src/client/entities/common/blip/IBlip.ts
+++ b/src/client/entities/common/blip/IBlip.ts
@@ -4,6 +4,7 @@ import { type IBlipColor, type IBlipSprite } from "@shared/entities";
 export interface IBlipOptions extends IWorldObjectOptions {}
 
 export interface IBlip extends IWorldObject {
+  get name(): string;
   get sprite(): IBlipSprite;
   get color(): number;
   get alpha(): number;

--- a/src/client/entities/common/colshape/IColshape.ts
+++ b/src/client/entities/common/colshape/IColshape.ts
@@ -2,4 +2,6 @@ import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
 
 export interface IColshapeOptions extends IWorldObjectOptions {}
 
-export interface IColshape extends IWorldObject {}
+export interface IColshape extends IWorldObject {
+  get key(): string | undefined;
+}

--- a/src/client/entities/common/vehicle/IVehicle.ts
+++ b/src/client/entities/common/vehicle/IVehicle.ts
@@ -44,8 +44,8 @@ export interface IVehicle extends IEntity {
   get windowTint(): number;
   setWheelType(wheelType: number): void;
   get wheelType(): number;
-  setNumberPlateTextIndex(index: number): void;
-  get numberPlateTextIndex(): number;
+  setNumberPlateType(index: number): void;
+  get numberPlateType(): number;
 
   setDoorOpen(doorIndex: number, loose: boolean, openInstantly: boolean): void;
   setDoorShut(doorIndex: number, instantly: boolean): void;

--- a/src/client/entities/common/vehicle/IVehiclesManager.ts
+++ b/src/client/entities/common/vehicle/IVehiclesManager.ts
@@ -4,6 +4,8 @@ import { type IVehicle } from "./IVehicle";
 export interface IVehicleCreateOptions extends IEntityCreateOptions {
   engine: boolean;
   locked: boolean;
+  numberPlate?: string;
+  numberPlateType?: number;
 }
 
 export interface IVehiclesManager extends IEntitiesManager<IVehicle> {

--- a/src/client/entities/ragemp/blip/RageBlip.ts
+++ b/src/client/entities/ragemp/blip/RageBlip.ts
@@ -4,10 +4,13 @@ import { type IBlipColor, type IBlipSprite } from "@shared/entities";
 
 export interface IRageBlipOptions extends IRageWorldObjectOptions<EntityMp> {
   global: boolean;
+  name: string;
 }
 
 export class RageBlip extends RageWorldObject<EntityMp> implements IBlip {
   private readonly _global: boolean;
+
+  private readonly _name: string;
 
   private get _blipEntity(): BlipMp {
     return this.mpEntity as unknown as BlipMp;
@@ -15,6 +18,10 @@ export class RageBlip extends RageWorldObject<EntityMp> implements IBlip {
 
   public get sprite(): IBlipSprite {
     return this._blipEntity.getSprite();
+  }
+
+  public get name(): string {
+    return this._name;
   }
 
   public get color(): IBlipColor {
@@ -36,6 +43,7 @@ export class RageBlip extends RageWorldObject<EntityMp> implements IBlip {
   public constructor(options: IRageBlipOptions) {
     super(options);
     this._global = options.global;
+    this._name = options.name;
   }
 
   public setSprite(value: IBlipSprite): void {

--- a/src/client/entities/ragemp/blip/RageBlipsManager.ts
+++ b/src/client/entities/ragemp/blip/RageBlipsManager.ts
@@ -20,6 +20,7 @@ export class RageBlipsManager extends RageWorldObjectsManager<RageBlip> implemen
     const blip = new RageBlip({
       mpEntity: mpEntity as unknown as EntityMp,
       global,
+      name: options.name ?? "",
     });
     this.registerBaseObject(blip);
 

--- a/src/client/entities/ragemp/colshape/RageColshape.ts
+++ b/src/client/entities/ragemp/colshape/RageColshape.ts
@@ -6,4 +6,9 @@ export abstract class RageColshape extends RageWorldObject<ColshapeMp> {
   protected constructor(options: IRageColshapeOptions) {
     super(options);
   }
+
+  public get key(): string | undefined {
+    const value = this.mpEntity.getVariable("key");
+    return typeof value === "string" ? value : undefined;
+  }
 }

--- a/src/client/entities/ragemp/vehicle/RageVehicle.ts
+++ b/src/client/entities/ragemp/vehicle/RageVehicle.ts
@@ -135,11 +135,11 @@ export class RageVehicle extends RageEntity<VehicleMp> implements IVehicle {
     return this.mpEntity.getWheelType();
   }
 
-  public setNumberPlateTextIndex(index: number): void {
+  public setNumberPlateType(index: number): void {
     this.mpEntity.setNumberPlateTextIndex(index);
   }
 
-  public get numberPlateTextIndex(): number {
+  public get numberPlateType(): number {
     return this.mpEntity.getNumberPlateTextIndex();
   }
 

--- a/src/server/entities/altv/colshape/AltVColshape.ts
+++ b/src/server/entities/altv/colshape/AltVColshape.ts
@@ -8,6 +8,11 @@ export abstract class AltVColshape extends AltVWorldObject<Colshape> {
     super(options);
   }
 
+  public get key(): string | undefined {
+    const value = this.getNetData("key");
+    return typeof value === "string" ? value : undefined;
+  }
+
   public getNetData(name: string): unknown {
     return this.mpEntity.getSyncedMeta(name);
   }

--- a/src/server/entities/altv/colshape/AltVColshapesManager.ts
+++ b/src/server/entities/altv/colshape/AltVColshapesManager.ts
@@ -64,65 +64,70 @@ export class AltVColshapesManager extends AltVWorldObjectsManager<AltVColshape> 
   }
 
   public createCircle(options: IAltVCircleColshapeCreateOptions): AltVCircleColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y } = position;
 
     const mpEntity = new ColshapeCircle(x, y, range);
     mpEntity.dimension = dimension;
 
     const colshape = new AltVCircleColshape({ mpEntity });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createCuboid(options: IAltVCuboidColshapeCreateOptions): AltVCuboidColshape {
-    const { width, depth, height, position, dimension } = options;
+    const { width, depth, height, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = new ColshapeCuboid(x, y, z, x + width, y + depth, z + height);
     mpEntity.dimension = dimension;
 
     const colshape = new AltVCuboidColshape({ mpEntity });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createCylinder(options: IAltVCylinderColshapeCreateOptions): AltVCylinderColshape {
-    const { height, range, position, dimension } = options;
+    const { height, range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = new ColshapeCylinder(x, y, z, range, height);
     mpEntity.dimension = dimension;
 
     const colshape = new AltVCylinderColshape({ mpEntity });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createRectangle(options: IAltVRectangleColshapeCreateOptions): AltVRectangleColshape {
-    const { width, height, position, dimension } = options;
+    const { width, height, position, dimension, key } = options;
     const { x, y } = position;
 
     const mpEntity = new ColshapeRectangle(x, y, x + width, y + height);
     mpEntity.dimension = dimension;
 
     const colshape = new AltVRectangleColshape({ mpEntity });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createSphere(options: IAltVSphereColshapeCreateOptions): AltVSphereColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = new ColshapeSphere(x, y, z, range);
     mpEntity.dimension = dimension;
 
     const colshape = new AltVSphereColshape({ mpEntity });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;

--- a/src/server/entities/ccmp/colshape/CCMPColshape.ts
+++ b/src/server/entities/ccmp/colshape/CCMPColshape.ts
@@ -35,6 +35,10 @@ export abstract class CCMPColshape extends CCMPWorldObject implements IColshape 
     return this._ccmpColshape.dimension;
   }
 
+  public get key(): string | undefined {
+    return this._ccmpColshape.key;
+  }
+
   public get playersInside(): readonly CcmpPlayer[] {
     return this._ccmpColshape.playersInside;
   }

--- a/src/server/entities/ccmp/colshape/CCMPColshapesManager.ts
+++ b/src/server/entities/ccmp/colshape/CCMPColshapesManager.ts
@@ -52,9 +52,10 @@ export class CCMPColshapesManager extends CCMPWorldObjectsManager<CCMPColshape> 
   }
 
   public createCircle(options: ICCMPCircleColshapeCreateOptions): CCMPCircleColshape {
-    const { position, range, dimension } = options;
+    const { position, range, dimension, key } = options;
+    const extras = key === undefined ? { dimension } : { dimension, key };
 
-    const ccmpColshape = ccmp.colshapes.createCircle(position.x, position.y, position.z, range, { dimension });
+    const ccmpColshape = ccmp.colshapes.createCircle(position.x, position.y, position.z, range, extras);
     if (!ccmpColshape) {
       throw new Error("CCMPColshapesManager.createCircle: ccmp.colshapes.createCircle failed (server full?)");
     }
@@ -69,7 +70,8 @@ export class CCMPColshapesManager extends CCMPWorldObjectsManager<CCMPColshape> 
   }
 
   public createCuboid(options: ICCMPCuboidColshapeCreateOptions): CCMPCuboidColshape {
-    const { position, width, depth, height, dimension } = options;
+    const { position, width, depth, height, dimension, key } = options;
+    const extras = key === undefined ? { dimension } : { dimension, key };
 
     // CCMP cube uses HALF-extents (centered at position); rock-mod options describe full sizes.
     const ccmpColshape = ccmp.colshapes.createCube(
@@ -79,7 +81,7 @@ export class CCMPColshapesManager extends CCMPWorldObjectsManager<CCMPColshape> 
       width / 2,
       depth / 2,
       height / 2,
-      { dimension },
+      extras,
     );
     if (!ccmpColshape) {
       throw new Error("CCMPColshapesManager.createCuboid: ccmp.colshapes.createCube failed (server full?)");
@@ -95,11 +97,10 @@ export class CCMPColshapesManager extends CCMPWorldObjectsManager<CCMPColshape> 
   }
 
   public createCylinder(options: ICCMPCylinderColshapeCreateOptions): CCMPCylinderColshape {
-    const { position, range, height, dimension } = options;
+    const { position, range, height, dimension, key } = options;
+    const extras = key === undefined ? { dimension } : { dimension, key };
 
-    const ccmpColshape = ccmp.colshapes.createCylinder(position.x, position.y, position.z, range, height, {
-      dimension,
-    });
+    const ccmpColshape = ccmp.colshapes.createCylinder(position.x, position.y, position.z, range, height, extras);
     if (!ccmpColshape) {
       throw new Error("CCMPColshapesManager.createCylinder: ccmp.colshapes.createCylinder failed (server full?)");
     }
@@ -118,9 +119,10 @@ export class CCMPColshapesManager extends CCMPWorldObjectsManager<CCMPColshape> 
   }
 
   public createSphere(options: ICCMPSphereColshapeCreateOptions): CCMPSphereColshape {
-    const { position, range, dimension } = options;
+    const { position, range, dimension, key } = options;
+    const extras = key === undefined ? { dimension } : { dimension, key };
 
-    const ccmpColshape = ccmp.colshapes.createSphere(position.x, position.y, position.z, range, { dimension });
+    const ccmpColshape = ccmp.colshapes.createSphere(position.x, position.y, position.z, range, extras);
     if (!ccmpColshape) {
       throw new Error("CCMPColshapesManager.createSphere: ccmp.colshapes.createSphere failed (server full?)");
     }

--- a/src/server/entities/ccmp/vehicle/CCMPVehicle.ts
+++ b/src/server/entities/ccmp/vehicle/CCMPVehicle.ts
@@ -12,6 +12,10 @@ export interface ICCMPVehicleOptions {
   onDestroy: (vehicle: CCMPVehicle) => void;
 }
 
+type CcmpVehicleWithNumberPlate = CcmpVehicle & {
+  numberPlate: string;
+};
+
 export class CCMPVehicle extends CCMPEntity implements IVehicle {
   private static readonly _customPrimaryColorMeta = "rockMod:customPrimaryColor";
 
@@ -76,7 +80,7 @@ export class CCMPVehicle extends CCMPEntity implements IVehicle {
   }
 
   public get numberPlate(): string {
-    return this._ccmpVehicle.numberPlateText;
+    return (this._ccmpVehicle as CcmpVehicleWithNumberPlate).numberPlate;
   }
 
   public get isLocked(): boolean {
@@ -167,7 +171,7 @@ export class CCMPVehicle extends CCMPEntity implements IVehicle {
   }
 
   public setNumberPlate(value: string): void {
-    this._ccmpVehicle.numberPlateText = value;
+    (this._ccmpVehicle as CcmpVehicleWithNumberPlate).numberPlate = value;
   }
 
   public setLocked(value: boolean): void {

--- a/src/server/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/server/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -28,7 +28,14 @@ export class CCMPVehiclesManager extends CCMPEntitiesManager<CCMPVehicle> implem
     if (options.numberPlate !== undefined) createOptions.numberPlate = options.numberPlate;
     if (options.numberPlateType !== undefined) createOptions.numberPlateType = options.numberPlateType;
 
-    const ccmpVehicle = ccmp.vehicles.create(ccmp.hash(model), position.x, position.y, position.z, rotation.z, createOptions);
+    const ccmpVehicle = ccmp.vehicles.create(
+      ccmp.hash(model),
+      position.x,
+      position.y,
+      position.z,
+      rotation.z,
+      createOptions,
+    );
     if (!ccmpVehicle) {
       throw new Error("CCMPVehiclesManager.create: ccmp.vehicles.create failed (server full?)");
     }

--- a/src/server/entities/ccmp/vehicle/CCMPVehiclesManager.ts
+++ b/src/server/entities/ccmp/vehicle/CCMPVehiclesManager.ts
@@ -12,18 +12,25 @@ export class CCMPVehiclesManager extends CCMPEntitiesManager<CCMPVehicle> implem
   }
 
   public create(options: ICCMPVehicleCreateOptions): CCMPVehicle {
-    const { model, position, rotation, engine, dimension } = options;
-    // CCMP vehicles API has no `locked` field yet — it is silently ignored.
+    const { model, position, rotation, engine, dimension, locked } = options;
+    const createOptions: {
+      dimension: number;
+      engineOn: boolean;
+      lockState: number;
+      numberPlate?: string;
+      numberPlateType?: number;
+    } = {
+      dimension,
+      engineOn: engine,
+      lockState: locked ? 2 : 1,
+    };
 
-    const ccmpVehicle = ccmp.vehicles.create(ccmp.hash(model), position.x, position.y, position.z, rotation.z);
+    if (options.numberPlate !== undefined) createOptions.numberPlate = options.numberPlate;
+    if (options.numberPlateType !== undefined) createOptions.numberPlateType = options.numberPlateType;
+
+    const ccmpVehicle = ccmp.vehicles.create(ccmp.hash(model), position.x, position.y, position.z, rotation.z, createOptions);
     if (!ccmpVehicle) {
       throw new Error("CCMPVehiclesManager.create: ccmp.vehicles.create failed (server full?)");
-    }
-
-    ccmpVehicle.dimension = dimension;
-
-    if (engine) {
-      ccmpVehicle.engineOn = true;
     }
 
     const vehicle = new CCMPVehicle({

--- a/src/server/entities/common/colshape/IColshape.ts
+++ b/src/server/entities/common/colshape/IColshape.ts
@@ -3,6 +3,7 @@ import { type IWorldObject, type IWorldObjectOptions } from "../worldObject";
 export interface IColshapeOptions extends IWorldObjectOptions {}
 
 export interface IColshape extends IWorldObject {
+  get key(): string | undefined;
   getNetData(name: string): unknown;
   setNetData(name: string, value: unknown): void;
 }

--- a/src/server/entities/common/colshape/IColshapesManager.ts
+++ b/src/server/entities/common/colshape/IColshapesManager.ts
@@ -8,26 +8,31 @@ import { type ISphereColshape } from "./ISphereColshape";
 import { type IPlayer } from "../player";
 
 export interface ICircleColshapeCreateOptions extends IWorldObjectCreateOptions {
+  key?: string;
   range: number;
 }
 
 export interface ICuboidColshapeCreateOptions extends IWorldObjectCreateOptions {
+  key?: string;
   width: number;
   depth: number;
   height: number;
 }
 
 export interface ICylinderColshapeCreateOptions extends IWorldObjectCreateOptions {
+  key?: string;
   range: number;
   height: number;
 }
 
 export interface IRectangleColshapeCreateOptions extends IWorldObjectCreateOptions {
+  key?: string;
   width: number;
   height: number;
 }
 
 export interface ISphereColshapeCreateOptions extends IWorldObjectCreateOptions {
+  key?: string;
   range: number;
 }
 

--- a/src/server/entities/common/vehicle/IVehiclesManager.ts
+++ b/src/server/entities/common/vehicle/IVehiclesManager.ts
@@ -4,6 +4,8 @@ import { type IVehicle } from "./IVehicle";
 export interface IVehicleCreateOptions extends IEntityCreateOptions {
   engine: boolean;
   locked: boolean;
+  numberPlate?: string;
+  numberPlateType?: number;
 }
 
 export interface IVehiclesManager extends IEntitiesManager<IVehicle> {

--- a/src/server/entities/mock/colshape/MockColshape.ts
+++ b/src/server/entities/mock/colshape/MockColshape.ts
@@ -12,6 +12,11 @@ export abstract class MockColshape extends MockWorldObject implements IColshape 
     this._netData = new Map();
   }
 
+  public get key(): string | undefined {
+    const value = this.getNetData("key");
+    return typeof value === "string" ? value : undefined;
+  }
+
   public getNetData(name: string): unknown {
     return this._netData.get(name);
   }

--- a/src/server/entities/mock/colshape/MockColshapesManager.ts
+++ b/src/server/entities/mock/colshape/MockColshapesManager.ts
@@ -35,7 +35,7 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
   }
 
   public createCircle(options: IMockCircleColshapeCreateOptions): MockCircleColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y } = position;
 
     const colshape = new MockCircleColshape({
@@ -46,12 +46,14 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
       dimension,
     });
 
+    if (key !== undefined) colshape.setNetData("key", key);
+
     this.registerBaseObject(colshape);
     return colshape;
   }
 
   public createCuboid(options: IMockCuboidColshapeCreateOptions): MockCuboidColshape {
-    const { width, depth, height, position, dimension } = options;
+    const { width, depth, height, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const colshape = new MockCuboidColshape({
@@ -64,12 +66,14 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
       dimension,
     });
 
+    if (key !== undefined) colshape.setNetData("key", key);
+
     this.registerBaseObject(colshape);
     return colshape;
   }
 
   public createCylinder(options: IMockCylinderColshapeCreateOptions): MockCylinderColshape {
-    const { height, range, position, dimension } = options;
+    const { height, range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const colshape = new MockCylinderColshape({
@@ -81,12 +85,14 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
       dimension,
     });
 
+    if (key !== undefined) colshape.setNetData("key", key);
+
     this.registerBaseObject(colshape);
     return colshape;
   }
 
   public createRectangle(options: IMockRectangleColshapeCreateOptions): MockRectangleColshape {
-    const { width, height, position, dimension } = options;
+    const { width, height, position, dimension, key } = options;
     const { x, y } = position;
 
     const colshape = new MockRectangleColshape({
@@ -98,12 +104,14 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
       dimension,
     });
 
+    if (key !== undefined) colshape.setNetData("key", key);
+
     this.registerBaseObject(colshape);
     return colshape;
   }
 
   public createSphere(options: IMockSphereColshapeCreateOptions): MockSphereColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const colshape = new MockSphereColshape({
@@ -113,6 +121,8 @@ export class MockColshapesManager extends MockWorldObjectsManager<MockColshape> 
       position: new Vector3D(x, y, z),
       dimension,
     });
+
+    if (key !== undefined) colshape.setNetData("key", key);
 
     this.registerBaseObject(colshape);
     return colshape;

--- a/src/server/entities/ragemp/colshape/RageColshape.ts
+++ b/src/server/entities/ragemp/colshape/RageColshape.ts
@@ -10,6 +10,11 @@ export abstract class RageColshape extends RageWorldObject<ColshapeMp> {
     super(options);
   }
 
+  public get key(): string | undefined {
+    const value = this.getNetData("key");
+    return typeof value === "string" ? value : undefined;
+  }
+
   public getNetData(name: string): unknown {
     return this.mpEntity.getVariable(name);
   }

--- a/src/server/entities/ragemp/colshape/RageColshapesManager.ts
+++ b/src/server/entities/ragemp/colshape/RageColshapesManager.ts
@@ -54,65 +54,70 @@ export class RageColshapesManager extends RageWorldObjectsManager<RageColshape> 
   }
 
   public createCircle(options: IRageCircleColshapeCreateOptions): RageCircleColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y } = position;
 
     const mpEntity = mp.colshapes.newCircle(x, y, range, dimension);
     mpEntity.isExists = (): boolean => mp.colshapes.exists(mpEntity);
 
     const colshape = new RageCircleColshape({ mpEntity, position });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createCuboid(options: IRageCuboidColshapeCreateOptions): RageCuboidColshape {
-    const { width, depth, height, position, dimension } = options;
+    const { width, depth, height, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = mp.colshapes.newCuboid(x, y, z, width, depth, height, dimension);
     mpEntity.isExists = (): boolean => mp.colshapes.exists(mpEntity);
 
     const colshape = new RageCuboidColshape({ mpEntity, position });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createCylinder(options: IRageCylinderColshapeCreateOptions): RageCylinderColshape {
-    const { height, range, position, dimension } = options;
+    const { height, range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = mp.colshapes.newTube(x, y, z, height, range, dimension);
     mpEntity.isExists = (): boolean => mp.colshapes.exists(mpEntity);
 
     const colshape = new RageCylinderColshape({ mpEntity, position });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createRectangle(options: IRageRectangleColshapeCreateOptions): RageRectangleColshape {
-    const { width, height, position, dimension } = options;
+    const { width, height, position, dimension, key } = options;
     const { x, y } = position;
 
     const mpEntity = mp.colshapes.newRectangle(x, y, width, height, dimension);
     mpEntity.isExists = (): boolean => mp.colshapes.exists(mpEntity);
 
     const colshape = new RageRectangleColshape({ mpEntity, position });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;
   }
 
   public createSphere(options: IRageSphereColshapeCreateOptions): RageSphereColshape {
-    const { range, position, dimension } = options;
+    const { range, position, dimension, key } = options;
     const { x, y, z } = position;
 
     const mpEntity = mp.colshapes.newSphere(x, y, z, range, dimension);
     mpEntity.isExists = (): boolean => mp.colshapes.exists(mpEntity);
 
     const colshape = new RageSphereColshape({ mpEntity, position });
+    if (key !== undefined) colshape.setNetData("key", key);
     this.registerBaseObject(colshape);
 
     return colshape;


### PR DESCRIPTION
## 0.25.3

This release focuses on CCMP compatibility fixes and shared entity metadata improvements.

### Added
- Added `key` support for colshape creation and exposed `colshape.key` across supported runtimes.
- Exposed the client-side blip `name` getter.
- Added vehicle creation support for `numberPlate` and `numberPlateType`.

### Fixed
- Fixed CCMP local player pool synchronization so local and remote players are properly primed from the runtime.
- Fixed CCMP vehicle initialization for engine state, lock state, number plates, and number plate type.
- Fixed CCMP ped rotation reads to use heading-based rotation.
- Fixed CCMP colshape key reads to use the persistent runtime key.
- Preserved vendored runtime type declarations from Prettier rewrites.

### Changed
- Updated `@classic-mp/types` to `1.9.0`.