### PR TITLE
Release 0.26.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rock-mod",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rock-mod",
-      "version": "0.25.3",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@swc/helpers": "^0.5.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.25.3",
       "license": "MIT",
       "dependencies": {
-        "@swc/helpers": "^0.5.15"
+        "@swc/helpers": "^0.5.15",
+        "tslib": "^2.8.1"
       },
       "devDependencies": {
         "@classic-mp/types": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rock-mod",
-  "version": "0.25.3",
+  "version": "0.26.0",
   "description": "Rock-Mod is a powerful framework designed for creating and managing mods for Grand Theft Auto (GTA) games.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
   "author": "xvetal",
   "license": "MIT",
   "dependencies": {
-    "@swc/helpers": "^0.5.15"
+    "@swc/helpers": "^0.5.15",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@classic-mp/types": "^1.9.0",

--- a/src/client/@types/ragemp/types-client/index.d.ts
+++ b/src/client/@types/ragemp/types-client/index.d.ts
@@ -1260,7 +1260,7 @@ declare interface IClientEvents {
     weapon: number,
     boneIndex: number,
     damage: number,
-  ) => void;
+  ) => boolean | void;
   outgoingDamage: (
     sourceEntity: EntityMp,
     targetEntity: EntityMp,

--- a/src/client/@types/ragemp/types-client/index.d.ts
+++ b/src/client/@types/ragemp/types-client/index.d.ts
@@ -1268,7 +1268,7 @@ declare interface IClientEvents {
     weapon: number,
     boneIndex: number,
     damage: number,
-  ) => void;
+  ) => boolean | void;
   meleeActionDamage: (
     source: PlayerMp,
     target: PlayerMp,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -14,5 +14,6 @@ export {
   IWorldObject as IRockModWorldObject,
   ICamera as IRockModCamera,
 } from "./entities";
+export { type IOutgoingDamageEvent as IRockModOutgoingDamageEvent } from "./net/common/events/types";
 export * from "./game";
 export * from "./console";

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,5 +15,6 @@ export {
   ICamera as IRockModCamera,
 } from "./entities";
 export { type IOutgoingDamageEvent as IRockModOutgoingDamageEvent } from "./net/common/events/types";
+export { type IIncomingDamageEvent as IRockModIncomingDamageEvent } from "./net/common/events/types";
 export * from "./game";
 export * from "./console";

--- a/src/client/net/common/events/types.ts
+++ b/src/client/net/common/events/types.ts
@@ -1,4 +1,4 @@
-import { type IBaseObject, type IPlayer, type IVehicle } from "@RockMod/client/entities";
+import { type IBaseObject, type IEntity, type IPlayer, type IVehicle } from "@RockMod/client/entities";
 import { type IVector3D } from "@shared/common/utils";
 
 export enum ClientInternalEventName {
@@ -15,6 +15,7 @@ export enum ClientInternalEventName {
   PlayerDeath = "rm::playerDeath",
   PlayerSpawn = "rm::playerSpawn",
   PlayerWeaponShot = "rm::playerWeaponShot",
+  OutgoingDamage = "rm::outgoingDamage",
   Render = "rm::render",
   Click = "rm::click",
   SyncedMetaChange = "rm::syncedMetaChange",
@@ -31,6 +32,15 @@ export interface IClickOptions {
   hitEntity: number | null;
 }
 
+export interface IOutgoingDamageEvent {
+  source: IEntity | null;
+  target: IEntity | null;
+  weaponHash: number;
+  boneIndex: number;
+  nativeDamage: number;
+  cancel(): void;
+}
+
 export interface IClientInternalEvents {
   [ClientInternalEventName.PlayerConnected]: (player: IPlayer) => void;
   [ClientInternalEventName.PlayerDisconnected]: (player: IPlayer) => void;
@@ -45,6 +55,7 @@ export interface IClientInternalEvents {
   [ClientInternalEventName.PlayerDeath]: (player: IPlayer) => void;
   [ClientInternalEventName.PlayerSpawn]: (player: IPlayer) => void;
   [ClientInternalEventName.PlayerWeaponShot]: () => void;
+  [ClientInternalEventName.OutgoingDamage]: (event: IOutgoingDamageEvent) => void;
   [ClientInternalEventName.Render]: () => void;
   [ClientInternalEventName.Click]: (options: IClickOptions) => void;
   [ClientInternalEventName.SyncedMetaChange]: (

--- a/src/client/net/common/events/types.ts
+++ b/src/client/net/common/events/types.ts
@@ -16,6 +16,7 @@ export enum ClientInternalEventName {
   PlayerSpawn = "rm::playerSpawn",
   PlayerWeaponShot = "rm::playerWeaponShot",
   OutgoingDamage = "rm::outgoingDamage",
+  IncomingDamage = "rm::incomingDamage",
   Render = "rm::render",
   Click = "rm::click",
   SyncedMetaChange = "rm::syncedMetaChange",
@@ -34,6 +35,17 @@ export interface IClickOptions {
 
 export interface IOutgoingDamageEvent {
   source: IEntity | null;
+  target: IEntity | null;
+  targetPlayer: IPlayer | null;
+  weaponHash: number;
+  boneIndex: number;
+  nativeDamage: number;
+  cancel(): void;
+}
+
+export interface IIncomingDamageEvent {
+  source: IEntity | null;
+  sourcePlayer: IPlayer | null;
   target: IEntity | null;
   weaponHash: number;
   boneIndex: number;
@@ -56,6 +68,7 @@ export interface IClientInternalEvents {
   [ClientInternalEventName.PlayerSpawn]: (player: IPlayer) => void;
   [ClientInternalEventName.PlayerWeaponShot]: () => void;
   [ClientInternalEventName.OutgoingDamage]: (event: IOutgoingDamageEvent) => void;
+  [ClientInternalEventName.IncomingDamage]: (event: IIncomingDamageEvent) => void;
   [ClientInternalEventName.Render]: () => void;
   [ClientInternalEventName.Click]: (options: IClickOptions) => void;
   [ClientInternalEventName.SyncedMetaChange]: (

--- a/src/client/net/ragemp/events/RageEventsBridge.ts
+++ b/src/client/net/ragemp/events/RageEventsBridge.ts
@@ -1,6 +1,6 @@
 import { ClientInternalEventName } from "@RockMod/client/net/common/events/types";
 import { RockMod } from "@RockMod/client/RockMod";
-import { type IEntityPoolRouter, type IPlayer, type IVehicle } from "@RockMod/client/entities/common";
+import { type IEntity, type IEntityPoolRouter, type IPlayer, type IVehicle } from "@RockMod/client/entities/common";
 import { type IEventsBridge } from "@RockMod/client/net/common/events/IEventsBridge";
 import { ServerToClientEventName } from "@shared/net/common/events/types";
 import { type IEventsManager } from "@RockMod/client/net/common/events/IEventsManager";
@@ -34,6 +34,7 @@ export class RageEventsBridge implements IEventsBridge {
           return;
         }
 
+        mp.game.weapon.setEnableLocalOutgoingDamage(true);
         this._events.emitInternal(ClientInternalEventName.PlayerReady, localPlayer);
       },
 
@@ -121,6 +122,23 @@ export class RageEventsBridge implements IEventsBridge {
         this._events.emitInternal(ClientInternalEventName.PlayerWeaponShot);
       },
 
+      outgoingDamage: (sourceEntity, targetEntity, _targetPlayer, weaponHash, boneIndex, nativeDamage) => {
+        let cancelled = false;
+
+        this._events.emitInternal(ClientInternalEventName.OutgoingDamage, {
+          source: this._resolveOrRegisterEntity(sourceEntity),
+          target: this._resolveOrRegisterEntity(targetEntity),
+          weaponHash,
+          boneIndex,
+          nativeDamage,
+          cancel: () => {
+            cancelled = true;
+          },
+        });
+
+        return cancelled;
+      },
+
       browserDomReady: () => {
         this._events.emitInternal(ClientInternalEventName.BrowserDomReady);
       },
@@ -180,5 +198,9 @@ export class RageEventsBridge implements IEventsBridge {
     this._rockMod?.vehicles.syncWithMpPool();
     this._rockMod?.objects.syncWithMpPool();
     this._rockMod?.peds.syncWithMpPool();
+  }
+
+  private _resolveOrRegisterEntity(mpEntity: EntityMp | null | undefined): IEntity | null {
+    return this._entityPoolRouter.resolveFromMp(mpEntity) ?? this._entityPoolRouter.registerFromMp(mpEntity);
   }
 }

--- a/src/client/net/ragemp/events/RageEventsBridge.ts
+++ b/src/client/net/ragemp/events/RageEventsBridge.ts
@@ -122,11 +122,30 @@ export class RageEventsBridge implements IEventsBridge {
         this._events.emitInternal(ClientInternalEventName.PlayerWeaponShot);
       },
 
-      outgoingDamage: (sourceEntity, targetEntity, _targetPlayer, weaponHash, boneIndex, nativeDamage) => {
+      outgoingDamage: (sourceEntity, targetEntity, targetPlayer, weaponHash, boneIndex, nativeDamage) => {
         let cancelled = false;
 
         this._events.emitInternal(ClientInternalEventName.OutgoingDamage, {
           source: this._resolveOrRegisterEntity(sourceEntity),
+          target: this._resolveOrRegisterEntity(targetEntity),
+          targetPlayer: this._resolveOrRegisterPlayer(targetPlayer),
+          weaponHash,
+          boneIndex,
+          nativeDamage,
+          cancel: () => {
+            cancelled = true;
+          },
+        });
+
+        return cancelled;
+      },
+
+      incomingDamage: (sourceEntity, sourcePlayer, targetEntity, weaponHash, boneIndex, nativeDamage) => {
+        let cancelled = false;
+
+        this._events.emitInternal(ClientInternalEventName.IncomingDamage, {
+          source: this._resolveOrRegisterEntity(sourceEntity),
+          sourcePlayer: this._resolveOrRegisterPlayer(sourcePlayer),
           target: this._resolveOrRegisterEntity(targetEntity),
           weaponHash,
           boneIndex,
@@ -202,5 +221,9 @@ export class RageEventsBridge implements IEventsBridge {
 
   private _resolveOrRegisterEntity(mpEntity: EntityMp | null | undefined): IEntity | null {
     return this._entityPoolRouter.resolveFromMp(mpEntity) ?? this._entityPoolRouter.registerFromMp(mpEntity);
+  }
+
+  private _resolveOrRegisterPlayer(mpPlayer: PlayerMp | null | undefined): IPlayer | null {
+    return this._resolveOrRegisterEntity(mpPlayer) as IPlayer | null;
   }
 }

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es2017",
     "module": "esnext",
+    "importHelpers": true,
     "moduleResolution": "node",
     "outDir": "../../dist/client",
     "rootDir": ".",


### PR DESCRIPTION
## What's Changed

### Added

- Added cancellable client-side weapon damage events:
  - `rm::outgoingDamage` for outgoing damage.
  - `rm::incomingDamage` for incoming damage.
- Damage events expose the source and target entities, related player, weapon hash, bone index, and native damage value.
- Damage can be prevented by calling `event.cancel()`.
- Enabled local outgoing damage tracking in the RAGE:MP client bridge.
- Added automatic resolution and registration of entities involved in damage events.

### Fixed

- TypeScript runtime helpers are now imported from `tslib`.
- Added `tslib` as a runtime dependency.