### PR TITLE
feat(player): implement VIMPPlayer vehicle getter

### DIFF
--- a/src/client/entities/vimp/player/VIMPPlayer.ts
+++ b/src/client/entities/vimp/player/VIMPPlayer.ts
@@ -265,19 +265,9 @@ export class VIMPPlayer implements IPlayer {
   }
 
   public get vehicle(): IVehicle | null {
-    const pedHandle = this.handle;
-    if (!pedHandle) return null;
-
-    // `atGetIn = false` — only a fully seated ped counts: while the entry
-    // animation is playing `vehicle` must stay null.
-    if (!vimp.natives.ped.isPedInAnyVehicle(pedHandle, false)) return null;
-
-    const vehicleHandle = vimp.natives.ped.getVehiclePedIsIn(pedHandle, false);
-    if (!vehicleHandle) return null;
-
-    // The native returns a GTA handle while the manager needs a client-local
-    // wrapper id. VIMP has no handle -> id index, so scan the pool.
-    const vimpVehicle = vimp.vehicles.all.find((vehicle) => vehicle.handle === vehicleHandle) ?? null;
+    // VIMP keeps its own handle -> Vehicle index and returns null until the
+    // player is fully seated: entry animation, not streamed or on foot give null.
+    const vimpVehicle = this._getNativePlayer()?.vehicle;
     if (!vimpVehicle) return null;
 
     return RockMod.instance.vehicles.findByID(vimpVehicle.id);

--- a/src/client/entities/vimp/player/VIMPPlayer.ts
+++ b/src/client/entities/vimp/player/VIMPPlayer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { type Player as VimpPlayer } from "@vimp-mp/types/client";
+import { RockMod } from "@RockMod/client/RockMod";
 import { BaseObjectType } from "@shared/entities";
 import { type IBaseObject } from "../../common/baseObject/IBaseObject";
 import { type IPlayer } from "../../common/player/IPlayer";
@@ -264,7 +265,22 @@ export class VIMPPlayer implements IPlayer {
   }
 
   public get vehicle(): IVehicle | null {
-    return null;
+    const pedHandle = this.handle;
+    if (!pedHandle) return null;
+
+    // `atGetIn = false` — only a fully seated ped counts: while the entry
+    // animation is playing `vehicle` must stay null.
+    if (!vimp.natives.ped.isPedInAnyVehicle(pedHandle, false)) return null;
+
+    const vehicleHandle = vimp.natives.ped.getVehiclePedIsIn(pedHandle, false);
+    if (!vehicleHandle) return null;
+
+    // The native returns a GTA handle while the manager needs a client-local
+    // wrapper id. VIMP has no handle -> id index, so scan the pool.
+    const vimpVehicle = vimp.vehicles.all.find((vehicle) => vehicle.handle === vehicleHandle) ?? null;
+    if (!vimpVehicle) return null;
+
+    return RockMod.instance.vehicles.findByID(vimpVehicle.id);
   }
 
   public get isVoice3DEnabled(): boolean {


### PR DESCRIPTION
## What it was

`VIMPPlayer.vehicle` was a stub that always returned `null`, while `IPlayer` promises `IVehicle | null`. Any gamemode code asking a player for their vehicle saw "on foot" on VIMP regardless of the real state.

## What it does now

The getter reads `vehicle` off the VIMP player and maps it to the Rock-Mod wrapper:

```ts
const vimpVehicle = this._getNativePlayer()?.vehicle;
if (!vimpVehicle) return null;

return RockMod.instance.vehicles.findByID(vimpVehicle.id);
```

The first commit implemented the getter over natives — `isPedInAnyVehicle` → `getVehiclePedIsIn` → linear scan of `vimp.vehicles.all` — because VIMP exposed no `handle -> wrapper` index. The second commit drops all of that: the index now lives in the client and `Player.vehicle` resolves in O(1).

The `atGetIn = false` semantics are preserved, they just moved into VIMP: `vehicle` is `null` while the entry animation is playing, when the vehicle is not streamed, and when the player is on foot.

## Dependencies

Merge order matters:

1. A `@vimp-mp/types` release that declares `readonly vehicle: Vehicle | null` on the **client** `Player` — this repo pins `@vimp-mp/types@^2.0.0`, and 2.0.0 declares `vehicle` on the server `Player` only.
2. A client build that ships the getter and the `handle -> Vehicle` index behind it.
3. A `@vimp-mp/types` bump here.

Until step 1 is published, `npm run type:client:check` fails with `TS2339: Property 'vehicle' does not exist on type 'Player'` and CI on this PR stays red.

## Testing

- Rebased onto `dev` after the CCMP → VIMP rename (1.0.0); the change now lives in `src/client/entities/vimp/player/VIMPPlayer.ts`.
- `npm run lint:client:check` — clean.
- `npm run type:client:check` — `TS2339` against the published 2.0.0, as expected; clean with a local types build that declares the client getter.
- Not exercised in game: the change was split off a branch where the getter was only a helper, so there is no standalone gameplay test for it.
