### PR TITLE
feat(marker): implement VIMP marker setters

### DIFF
--- a/src/client/entities/vimp/marker/VIMPMarker.ts
+++ b/src/client/entities/vimp/marker/VIMPMarker.ts
@@ -4,10 +4,6 @@ import { type IRGBA, RGBA, type IVector3D, Vector3D } from "@shared/common/utils
 import { type Marker as VimpMarker } from "@vimp-mp/types/client";
 import { type IMarker } from "../../common/marker/IMarker";
 
-const notImplemented = (memberName: string): never => {
-  throw new Error(`VIMPMarker.${memberName}: not implemented`);
-};
-
 export class VIMPMarker implements IMarker {
   private _destroyed = false;
 
@@ -52,24 +48,24 @@ export class VIMPMarker implements IMarker {
     return this._vimpMarker.dimension;
   }
 
-  public setPosition(_value: IVector3D): void {
-    notImplemented("setPosition");
+  public setPosition(value: IVector3D): void {
+    this._vimpMarker.setPosition({ x: value.x, y: value.y, z: value.z });
   }
 
-  public setDimension(_value: number): void {
-    notImplemented("setDimension");
+  public setDimension(value: number): void {
+    this._vimpMarker.setDimension(value);
   }
 
   public setCoords(
-    _xPos: number,
-    _yPos: number,
-    _zPos: number,
+    xPos: number,
+    yPos: number,
+    zPos: number,
     _xAxis: boolean,
     _yAxis: boolean,
     _zAxis: boolean,
     _clearArea: boolean,
   ): void {
-    notImplemented("setCoords");
+    this._vimpMarker.setPosition({ x: xPos, y: yPos, z: zPos });
   }
 
   public get markerType(): IMarkerType {
@@ -122,20 +118,20 @@ export class VIMPMarker implements IMarker {
     return vimp.entities.getStreamSyncedMetaKeys(vimp.entities.ENTITY_TYPE.Marker, remoteId);
   }
 
-  public setVisible(_value: boolean): void {
-    notImplemented("setVisible");
+  public setVisible(value: boolean): void {
+    this._vimpMarker.setVisible(value);
   }
 
-  public setRotation(_value: IVector3D): void {
-    notImplemented("setRotation");
+  public setRotation(value: IVector3D): void {
+    this._vimpMarker.setRotation({ x: value.x, y: value.y, z: value.z });
   }
 
   public get scale(): number {
     return this._vimpMarker.scale;
   }
 
-  public setScale(_value: number): void {
-    notImplemented("setScale");
+  public setScale(value: number): void {
+    this._vimpMarker.setScale(value);
   }
 
   public get color(): IRGBA {
@@ -143,7 +139,7 @@ export class VIMPMarker implements IMarker {
     return new RGBA(r, g, b, a);
   }
 
-  public setColor(_value: IRGBA): void {
-    notImplemented("setColor");
+  public setColor(value: IRGBA): void {
+    this._vimpMarker.setColor({ r: value.r, g: value.g, b: value.b, a: value.a ?? 255 });
   }
 }


### PR DESCRIPTION
## What it was

Every `VIMPMarker` setter was a `notImplemented` stub that threw. The fishing cast marker updates its position from `rm::render` every frame, so on VIMP the marker rendered once and froze, while the thrown error flooded the client log on every frame (hard enough to crash the dev panel).

The stubs were honest: the VIMP client `Marker` API used to be immutable after creation — `readonly` properties plus `destroy()`, nothing else.

## What it does now

VIMP now exposes local-marker mutation, and the adapter delegates to it directly:

- `setPosition`, `setRotation`, `setScale`, `setColor`, `setVisible`, `setDimension` → same-name methods on the VIMP marker.
- `setCoords` maps to `setPosition`: the axis flags and `clearArea` only make sense for GTA entities, and VIMP markers are drawn by the client without one.
- The `notImplemented` helper is gone from the file.

## Dependencies

1. `@vimp-mp/types@2.0.0`, which `dev` already pins, declares the marker setters — no bump needed.
2. A client build that ships the setters — deployed to the dev CDN as `DEV BUILD (Raider) 240820262335`.

## Testing

- Rebased onto `dev` after the CCMP → VIMP rename (1.0.0); the change now lives in `src/client/entities/vimp/marker/VIMPMarker.ts`.
- `npm run lint:client:check` and `npm run type:client:check` — clean against the published 2.0.0.
