### PR TITLE
fix(raycasting): use the blocking shape test probe on VIMP

### DIFF
--- a/src/client/game/vimp/raycasting/VIMPRaycastingManager.ts
+++ b/src/client/game/vimp/raycasting/VIMPRaycastingManager.ts
@@ -7,7 +7,12 @@ import {
 import { VIMPNativeCallerManager } from "../native/VIMPNativeCallerManager";
 import { Vector3D, type IVector3D } from "../../../../shared/common/utils";
 
-const START_SHAPE_TEST_LOS_PROBE = "0x7EE9F5D83DD4F90E";
+/**
+ * The blocking probe: its result is ready as soon as the call returns. The async variant
+ * (0x7EE9F5D83DD4F90E) is still pending on the same frame and reports `hit: false`, while
+ * `testPointToPoint` is synchronous by contract and reads the result right away.
+ */
+const START_EXPENSIVE_SYNCHRONOUS_SHAPE_TEST_LOS_PROBE = "0x377906D8A31E5586";
 const GET_SHAPE_TEST_RESULT = "0x3D87450E15D98694";
 const DEFAULT_TRACE_FLAG = 7;
 
@@ -29,7 +34,7 @@ export class VIMPRaycastingManager implements IRaycastingManager {
     flags?: number | number[],
   ): IRaycastResult | null {
     const shapeTestHandle = this._native.callNative(
-      START_SHAPE_TEST_LOS_PROBE,
+      START_EXPENSIVE_SYNCHRONOUS_SHAPE_TEST_LOS_PROBE,
       startPos.x,
       startPos.y,
       startPos.z,


### PR DESCRIPTION
## What it was

`VIMPRaycastingManager.testPointToPoint` started the **asynchronous** LOS probe `0x7EE9F5D83DD4F90E` and read `GET_SHAPE_TEST_RESULT` on the very next line. The async probe is still `pending` at that point, so `hit` came back `false` and the method returned `null` — every time, not intermittently.

`testPointToPoint` is synchronous by contract: call it, get a result. So on VIMP every camera raycast was dead — cast aiming, object placement ghosts, the polygon zone editor, offset measuring. Consumers that treat `null` as "ray hit nothing" silently fell through to their no-hit branch, which is why this read as a gameplay bug rather than an error.

## What it does now

Switches to the blocking variant `0x377906D8A31E5586` (`startExpensiveSynchronousShapeTestLosProbe`, a.k.a. `CastRayPointToPoint`), which does not return until the probe completes. It is already in the generated dispatch table, so no `natives.json` regeneration is needed.

This is the same native behind RAGE MP's `mp.raycasting.testPointToPoint`, so the VIMP adapter now behaves like the Rage one it mirrors. Signature, return shape and flag handling are unchanged; the extra cost is the probe itself, and callers are per-frame aim loops that already paid for two native calls per frame.

## Verified

Built together with #61 and installed on a mint dev stand. Cast aiming now resolves ground: the marker follows the crosshair, is green over water and red on solid ground, and sits on the surface instead of dropping to the sea-level plane under the terrain.

Rebased onto `dev` after the CCMP → VIMP rename (1.0.0); the change now lives in `src/client/game/vimp/raycasting/VIMPRaycastingManager.ts`. `npm run lint:client:check` and `npm run type:client:check` — clean.
