### PR TITLE
fix(keys): fire keyHold handlers on press on VIMP

### DIFF
--- a/src/client/game/vimp/keys/VIMPKeysManager.ts
+++ b/src/client/game/vimp/keys/VIMPKeysManager.ts
@@ -12,11 +12,12 @@ interface KeyBinding {
 /**
  * Реализация `IKeysManager` поверх нативных VIMP-событий `keyDown`/`keyUp`.
  *
- * Контрактные тонкости (зеркало RageMP `mp.keys.bind`):
- *  - `keyHold = false` → handler срабатывает на **нажатие** (`keyDown`).
- *  - `keyHold = true`  → handler срабатывает на **отпускание** (`keyUp`).
- *    Несмотря на название параметра, это НЕ "только когда зажато",
- *    это "при отпускании после нажатия". См. RageMP wiki.
+ * Contract (mirrors RageMP `mp.keys.bind`, see `KeysMp.bind` in the RageMP typings):
+ *  - `keyHold = true`  → the handler fires on **press** (`keyDown`).
+ *  - `keyHold = false` → the handler fires on **release** (`keyUp`).
+ *    Consumers bind `true` for press and `false` for release; that is what
+ *    RAGE does, and VIMP has to answer the same way, otherwise every
+ *    hold-to-act interaction starts on release and can never be cancelled.
  *
  * Архитектура:
  *  - Делаем **одну** глобальную подписку на `vimp.on('keyDown')` и одну
@@ -68,7 +69,7 @@ export class VIMPKeysManager implements IKeysManager {
       binding = { down: new Set(), up: new Set() };
       this._bindings.set(key, binding);
     }
-    (keyHold ? binding.up : binding.down).add(handler);
+    (keyHold ? binding.down : binding.up).add(handler);
   }
 
   public unbind(key: number, keyHold: boolean, handler?: KeyHandler): void {
@@ -77,7 +78,7 @@ export class VIMPKeysManager implements IKeysManager {
       return;
     }
 
-    const set = keyHold ? binding.up : binding.down;
+    const set = keyHold ? binding.down : binding.up;
     if (handler === undefined) {
       // RageMP-семантика: без handler — удаляем все подписки на (key, keyHold).
       set.clear();


### PR DESCRIPTION
## What it was

`VIMPKeysManager.bind(key, keyHold, handler)` put the handler into the `up` set when `keyHold = true` and into the `down` set when `keyHold = false`. RageMP `mp.keys.bind` does the opposite: `keyHold = true` triggers on keydown, `false` on keyup (that is also what `KeysMp.bind` in our RageMP typings says), and `RageKeysManager` passes the flag straight through. The file's own doc comment described the inverted contract, so the code matched the comment and both were wrong.

Gamemod consumers bind `true` for press and `false` for release. On VIMP that meant the release handler ran on press and the press handler ran on release. Anything built on "hold the key" broke in a very specific way: the hold started when the key was let go and there was no later release to cancel it. On Play this surfaced as the fishing cast: a single tap of E, no hold, and the cast progress bar fills by itself. The reel minigame input on Q/E is inverted the same way.

## What it does now

`bind` and `unbind` map `keyHold = true` to the `down` set and `false` to the `up` set. Dispatch, `isDown`/`isUp`, the single global `vimp.on` subscriptions and the auto-repeat behaviour are untouched, so this is a two-line swap plus the corrected doc comment.

## Verified

`npm run build` (shared, server, client) and `npm run lint:client:check` are clean; the emitted `dist/client/game/vimp/keys/VIMPKeysManager.js` carries the swapped mapping. Not yet run on a stand: the Play hold-cast code lives on a release branch that has to be rebuilt against this rock-mod before it can be checked in game.
