### PR TITLE
feat(object): pass placeOnGround through to VIMP object creation

### DIFF
--- a/src/server/entities/common/object/IObjectsManager.ts
+++ b/src/server/entities/common/object/IObjectsManager.ts
@@ -3,6 +3,7 @@ import { type IObject } from "./IObject";
 
 export interface IObjectCreateOptions extends IEntityCreateOptions {
   alpha: number;
+  placeOnGround?: boolean;
 }
 
 export interface IObjectsManager extends IEntitiesManager<IObject> {

--- a/src/server/entities/vimp/object/VIMPObjectsManager.ts
+++ b/src/server/entities/vimp/object/VIMPObjectsManager.ts
@@ -1,4 +1,5 @@
 import { type IObjectCreateOptions, type IObjectsManager } from "../../common/object/IObjectsManager";
+import type { ObjectCreateOptions } from "@vimp-mp/types/server";
 import { VIMPEntitiesManager } from "../entity/VIMPEntitiesManager";
 import { VIMPObject, type IVIMPObjectNative } from "./VIMPObject";
 
@@ -12,7 +13,13 @@ export class VIMPObjectsManager extends VIMPEntitiesManager<VIMPObject> implemen
   }
 
   public create(options: IVIMPObjectCreateOptions): VIMPObject {
-    const { model, position, dimension, rotation, alpha } = options;
+    const { model, position, dimension, rotation, alpha, placeOnGround } = options;
+
+    const extras: ObjectCreateOptions = { dimension, alpha };
+    if (placeOnGround !== undefined) {
+      extras.placeOnGround = placeOnGround;
+    }
+
     const vimpObject = vimp.objects.create(
       vimp.hash(model),
       position.x,
@@ -21,7 +28,7 @@ export class VIMPObjectsManager extends VIMPEntitiesManager<VIMPObject> implemen
       rotation.x,
       rotation.y,
       rotation.z,
-      { dimension, alpha },
+      extras,
     ) as IVIMPObjectNative | null;
 
     if (!vimpObject) {


### PR DESCRIPTION
## What it was

`VIMPPedsManager` already forwards the optional `placeOnGround` flag to
`vimp.peds.create`, but `VIMPObjectsManager` destructured only
`model`/`position`/`dimension`/`rotation`/`alpha` and dropped the flag on the
floor. A gamemode had no way to ask for — or opt out of — ground placement of a
server object on VIMP.

That mattered once VIMP stopped placing objects on the ground by default. It
used to align a prop by the bottom of its bounds instead of its origin, which
lifted props whose authored z already sat on the ground; the fix was to leave an
object where the gamemode put it, the way RageMP does. With the default gone, a
gamemode that does want the old behaviour needs a way to say so.

## What it does now

`IObjectCreateOptions` gains an optional `placeOnGround?: boolean`, and
`VIMPObjectsManager.create` forwards it in `extras` only when it is defined, so
an unset flag still means "whatever the platform default is". Other backends
keep ignoring the option — RageMP has no equivalent.

## Verified

`npm run build` (shared, server, client) and `npm run lint:server:check` are
clean. The change also shipped inside the composite build used on our VIMP stand
while the underlying placement fix was being tested there.
